### PR TITLE
feat(android): Add playlist drag & drop reordering and playback controls

### DIFF
--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/SharedRecordingsViewModel.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/SharedRecordingsViewModel.kt
@@ -13,9 +13,31 @@ class SharedRecordingsViewModel : ViewModel() {
     private val _recordingState = MutableStateFlow(RecordingState.IDLE)
     val recordingState: StateFlow<RecordingState> = _recordingState
 
+    // Playlist playback state
+    private val _playlistRecordings = MutableStateFlow<List<RecordingData>>(emptyList())
+    val playlistRecordings: StateFlow<List<RecordingData>> = _playlistRecordings
+
+    private val _playlistStartIndex = MutableStateFlow(0)
+    val playlistStartIndex: StateFlow<Int> = _playlistStartIndex
+
+    private val _isPlaylistMode = MutableStateFlow(false)
+    val isPlaylistMode: StateFlow<Boolean> = _isPlaylistMode
+
     // Function to set the selected recording
     fun selectRecording(recording: RecordingData) {
         _selectedRecording.value = recording
+        _isPlaylistMode.value = false
+        _playlistRecordings.value = emptyList()
+    }
+
+    // Function to set playlist playback
+    fun selectPlaylist(recordings: List<RecordingData>, startIndex: Int) {
+        if (recordings.isNotEmpty() && startIndex in recordings.indices) {
+            _playlistRecordings.value = recordings
+            _playlistStartIndex.value = startIndex
+            _selectedRecording.value = recordings[startIndex]
+            _isPlaylistMode.value = true
+        }
     }
 
     // 録音状態を更新する関数
@@ -25,7 +47,7 @@ class SharedRecordingsViewModel : ViewModel() {
 
     // 録音中またはポーズ中かどうかを確認する関数
     fun isRecordingOrPaused(): Boolean {
-        return _recordingState.value == RecordingState.RECORDING || 
+        return _recordingState.value == RecordingState.RECORDING ||
                _recordingState.value == RecordingState.PAUSED
     }
 }

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/db/PlaylistDao.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/db/PlaylistDao.kt
@@ -108,4 +108,17 @@ interface PlaylistDao {
         ORDER BY cr.position ASC
     """)
     fun getRecordingsForPlaylist(playlistUuid: UUID): Flow<List<RecordingEntity>>
+
+    @Query("UPDATE playlist_recording_cross_ref SET position = :newPosition WHERE playlist_uuid = :playlistUuid AND recording_uuid = :recordingUuid")
+    suspend fun updatePosition(playlistUuid: UUID, recordingUuid: UUID, newPosition: Int)
+
+    @Query("SELECT * FROM playlist_recording_cross_ref WHERE playlist_uuid = :playlistUuid ORDER BY position ASC")
+    suspend fun getCrossRefsForPlaylist(playlistUuid: UUID): List<PlaylistRecordingCrossRef>
+
+    @Transaction
+    suspend fun reorderRecordings(playlistUuid: UUID, recordingUuids: List<UUID>) {
+        recordingUuids.forEachIndexed { index, recordingUuid ->
+            updatePosition(playlistUuid, recordingUuid, index)
+        }
+    }
 }

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/play/PlaybackScreen.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/play/PlaybackScreen.kt
@@ -2,6 +2,12 @@ package com.entaku.simpleRecord.play
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.RepeatOne
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -21,13 +27,27 @@ fun PlaybackScreen(
     onPlayPause: () -> Unit,
     onStop: () -> Unit,
     onNavigateBack: () -> Unit,
-    onSpeedChange: (Float) -> Unit
+    onSpeedChange: (Float) -> Unit,
+    onToggleRepeat: () -> Unit = {},
+    onToggleShuffle: () -> Unit = {},
+    onPlayNext: () -> Unit = {},
+    onPlayPrevious: () -> Unit = {}
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        // Track info
+        if (playbackState.isPlaylistMode) {
+            Text(
+                text = "${playbackState.currentTrackIndex + 1} / ${playbackState.playlist.size}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+
         Text(text = "Playing: ${recordingData.title}")
 
         // 再生速度選択
@@ -67,9 +87,87 @@ fun PlaybackScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Button(onClick = onPlayPause) {
-            Text(text = if (playbackState.isPlaying) "Pause" else "Play")
+        // Playback controls with repeat/shuffle
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Shuffle button
+            IconButton(onClick = onToggleShuffle) {
+                Icon(
+                    imageVector = Icons.Default.Shuffle,
+                    contentDescription = "Shuffle",
+                    tint = if (playbackState.isShuffleEnabled)
+                        MaterialTheme.colorScheme.primary
+                    else
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // Previous button
+            IconButton(
+                onClick = onPlayPrevious,
+                enabled = playbackState.isPlaylistMode
+            ) {
+                Icon(
+                    imageVector = Icons.Default.SkipPrevious,
+                    contentDescription = "Previous",
+                    tint = if (playbackState.isPlaylistMode)
+                        MaterialTheme.colorScheme.onSurface
+                    else
+                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                )
+            }
+
+            // Play/Pause button
+            Button(onClick = onPlayPause) {
+                Text(text = if (playbackState.isPlaying) "Pause" else "Play")
+            }
+
+            // Next button
+            IconButton(
+                onClick = onPlayNext,
+                enabled = playbackState.isPlaylistMode
+            ) {
+                Icon(
+                    imageVector = Icons.Default.SkipNext,
+                    contentDescription = "Next",
+                    tint = if (playbackState.isPlaylistMode)
+                        MaterialTheme.colorScheme.onSurface
+                    else
+                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                )
+            }
+
+            // Repeat button
+            IconButton(onClick = onToggleRepeat) {
+                Icon(
+                    imageVector = when (playbackState.repeatMode) {
+                        RepeatMode.ONE -> Icons.Default.RepeatOne
+                        else -> Icons.Default.Repeat
+                    },
+                    contentDescription = "Repeat",
+                    tint = when (playbackState.repeatMode) {
+                        RepeatMode.OFF -> MaterialTheme.colorScheme.onSurfaceVariant
+                        else -> MaterialTheme.colorScheme.primary
+                    }
+                )
+            }
         }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Repeat mode indicator
+        Text(
+            text = when (playbackState.repeatMode) {
+                RepeatMode.OFF -> "Repeat: Off"
+                RepeatMode.ONE -> "Repeat: One"
+                RepeatMode.ALL -> "Repeat: All"
+            },
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
 
@@ -128,4 +226,3 @@ fun PlaybackScreenPreview() {
         onSpeedChange = { }
     )
 }
-

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/play/PlaybackViewModel.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/play/PlaybackViewModel.kt
@@ -5,6 +5,7 @@ import android.media.PlaybackParams
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.entaku.simpleRecord.RecordingData
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -13,11 +14,23 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.io.IOException
 
+enum class RepeatMode {
+    OFF,      // No repeat
+    ONE,      // Repeat current track
+    ALL       // Repeat entire playlist
+}
+
 // Playbackの状態をまとめたデータクラス
 data class PlaybackState(
     val isPlaying: Boolean = false,
     val currentPosition: Int = 0,
-    val playbackSpeed: Float = 1.0f
+    val playbackSpeed: Float = 1.0f,
+    val repeatMode: RepeatMode = RepeatMode.OFF,
+    val isShuffleEnabled: Boolean = false,
+    val currentTrackIndex: Int = 0,
+    val playlist: List<RecordingData> = emptyList(),
+    val shuffledIndices: List<Int> = emptyList(),
+    val isPlaylistMode: Boolean = false
 )
 
 class PlaybackViewModel : ViewModel() {
@@ -30,15 +43,218 @@ class PlaybackViewModel : ViewModel() {
     private var updateJob: Job? = null
 
     fun setupMediaPlayer(filePath: String) {
+        releaseMediaPlayer()
         mediaPlayer = MediaPlayer().apply {
             try {
                 setDataSource(filePath)
                 prepare()
+                setOnCompletionListener {
+                    handleTrackCompletion()
+                }
             } catch (e: IOException) {
                 Log.e("MediaPlayer", "Failed to set data source", e)
             } catch (e: IllegalStateException) {
                 Log.e("MediaPlayer", "Illegal state during media preparation", e)
             }
+        }
+    }
+
+    fun setupPlaylist(recordings: List<RecordingData>, startIndex: Int) {
+        if (recordings.isEmpty()) return
+
+        val shuffledIndices = if (_playbackState.value.isShuffleEnabled) {
+            createShuffledIndices(recordings.size, startIndex)
+        } else {
+            recordings.indices.toList()
+        }
+
+        _playbackState.update { currentState ->
+            currentState.copy(
+                playlist = recordings,
+                currentTrackIndex = startIndex,
+                shuffledIndices = shuffledIndices,
+                isPlaylistMode = true
+            )
+        }
+
+        val actualIndex = if (_playbackState.value.isShuffleEnabled) {
+            shuffledIndices.indexOf(startIndex).takeIf { it >= 0 } ?: 0
+        } else {
+            startIndex
+        }
+
+        playTrackAtIndex(actualIndex)
+    }
+
+    private fun createShuffledIndices(size: Int, startIndex: Int): List<Int> {
+        val indices = (0 until size).toMutableList()
+        indices.shuffle()
+        // Move the start index to the front
+        indices.remove(startIndex)
+        indices.add(0, startIndex)
+        return indices
+    }
+
+    private fun playTrackAtIndex(index: Int) {
+        val state = _playbackState.value
+        val playlist = state.playlist
+        if (playlist.isEmpty()) return
+
+        val actualIndex = if (state.isShuffleEnabled) {
+            state.shuffledIndices.getOrNull(index) ?: return
+        } else {
+            index
+        }
+
+        if (actualIndex < 0 || actualIndex >= playlist.size) return
+
+        val recording = playlist[actualIndex]
+
+        _playbackState.update { currentState ->
+            currentState.copy(
+                currentTrackIndex = actualIndex,
+                currentPosition = 0,
+                isPlaying = false
+            )
+        }
+
+        setupMediaPlayer(recording.filePath)
+        playOrPause() // Auto-play
+    }
+
+    private fun handleTrackCompletion() {
+        val state = _playbackState.value
+
+        stopUpdatingProgress()
+        _playbackState.update { it.copy(isPlaying = false) }
+
+        if (!state.isPlaylistMode) {
+            // Single track mode
+            when (state.repeatMode) {
+                RepeatMode.ONE, RepeatMode.ALL -> {
+                    mediaPlayer?.seekTo(0)
+                    playOrPause()
+                }
+                RepeatMode.OFF -> {
+                    // Do nothing, playback ends
+                }
+            }
+            return
+        }
+
+        // Playlist mode
+        when (state.repeatMode) {
+            RepeatMode.ONE -> {
+                // Repeat current track
+                mediaPlayer?.seekTo(0)
+                playOrPause()
+            }
+            RepeatMode.ALL -> {
+                // Play next track, loop to start if at end
+                val nextIndex = getNextTrackIndex(state)
+                playTrackAtIndex(nextIndex)
+            }
+            RepeatMode.OFF -> {
+                // Play next track if available
+                val currentIndex = if (state.isShuffleEnabled) {
+                    state.shuffledIndices.indexOf(state.currentTrackIndex)
+                } else {
+                    state.currentTrackIndex
+                }
+
+                if (currentIndex < state.playlist.size - 1) {
+                    playTrackAtIndex(currentIndex + 1)
+                }
+                // Otherwise, playback ends
+            }
+        }
+    }
+
+    private fun getNextTrackIndex(state: PlaybackState): Int {
+        val currentIndex = if (state.isShuffleEnabled) {
+            state.shuffledIndices.indexOf(state.currentTrackIndex)
+        } else {
+            state.currentTrackIndex
+        }
+
+        val nextIndex = currentIndex + 1
+        return if (nextIndex >= state.playlist.size) 0 else nextIndex
+    }
+
+    fun playNext() {
+        val state = _playbackState.value
+        if (!state.isPlaylistMode || state.playlist.isEmpty()) return
+
+        val currentIndex = if (state.isShuffleEnabled) {
+            state.shuffledIndices.indexOf(state.currentTrackIndex)
+        } else {
+            state.currentTrackIndex
+        }
+
+        val nextIndex = if (currentIndex < state.playlist.size - 1) {
+            currentIndex + 1
+        } else if (state.repeatMode == RepeatMode.ALL) {
+            0
+        } else {
+            return
+        }
+
+        playTrackAtIndex(nextIndex)
+    }
+
+    fun playPrevious() {
+        val state = _playbackState.value
+        if (!state.isPlaylistMode || state.playlist.isEmpty()) return
+
+        // If more than 3 seconds into the track, restart it
+        if (state.currentPosition > 3000) {
+            mediaPlayer?.seekTo(0)
+            _playbackState.update { it.copy(currentPosition = 0) }
+            return
+        }
+
+        val currentIndex = if (state.isShuffleEnabled) {
+            state.shuffledIndices.indexOf(state.currentTrackIndex)
+        } else {
+            state.currentTrackIndex
+        }
+
+        val prevIndex = if (currentIndex > 0) {
+            currentIndex - 1
+        } else if (state.repeatMode == RepeatMode.ALL) {
+            state.playlist.size - 1
+        } else {
+            0
+        }
+
+        playTrackAtIndex(prevIndex)
+    }
+
+    fun toggleRepeatMode() {
+        _playbackState.update { currentState ->
+            val newMode = when (currentState.repeatMode) {
+                RepeatMode.OFF -> RepeatMode.ALL
+                RepeatMode.ALL -> RepeatMode.ONE
+                RepeatMode.ONE -> RepeatMode.OFF
+            }
+            currentState.copy(repeatMode = newMode)
+        }
+    }
+
+    fun toggleShuffle() {
+        val state = _playbackState.value
+
+        _playbackState.update { currentState ->
+            val newShuffleEnabled = !currentState.isShuffleEnabled
+            val newShuffledIndices = if (newShuffleEnabled && currentState.playlist.isNotEmpty()) {
+                createShuffledIndices(currentState.playlist.size, currentState.currentTrackIndex)
+            } else {
+                currentState.playlist.indices.toList()
+            }
+            currentState.copy(
+                isShuffleEnabled = newShuffleEnabled,
+                shuffledIndices = newShuffledIndices
+            )
         }
     }
 
@@ -105,7 +321,7 @@ class PlaybackViewModel : ViewModel() {
         updateJob = null
     }
 
-    fun stopPlayback() {
+    private fun releaseMediaPlayer() {
         mediaPlayer?.let {
             try {
                 if (it.isPlaying) {
@@ -114,18 +330,31 @@ class PlaybackViewModel : ViewModel() {
                 it.reset()
                 it.release()
             } catch (e: IllegalStateException) {
-                Log.e("MediaPlayer", "Error stopping media player", e)
+                Log.e("MediaPlayer", "Error releasing media player", e)
             } finally {
                 mediaPlayer = null
             }
         }
+    }
+
+    fun stopPlayback() {
+        releaseMediaPlayer()
         stopUpdatingProgress()
         _playbackState.update { currentState ->
             currentState.copy(
                 isPlaying = false,
-                currentPosition = 0
+                currentPosition = 0,
+                isPlaylistMode = false,
+                playlist = emptyList(),
+                shuffledIndices = emptyList()
             )
         }
+    }
+
+    fun getCurrentRecording(): RecordingData? {
+        val state = _playbackState.value
+        if (!state.isPlaylistMode || state.playlist.isEmpty()) return null
+        return state.playlist.getOrNull(state.currentTrackIndex)
     }
 
     override fun onCleared() {

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/playlist/PlaylistDetailScreen.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/playlist/PlaylistDetailScreen.kt
@@ -1,6 +1,8 @@
 package com.entaku.simpleRecord.playlist
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,13 +12,17 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -33,19 +39,26 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.entaku.simpleRecord.RecordingData
 import com.entaku.simpleRecord.formatTime
 import kotlinx.coroutines.launch
 import java.time.format.DateTimeFormatter
 import java.util.UUID
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -54,8 +67,10 @@ fun PlaylistDetailScreen(
     allRecordings: List<RecordingData>,
     onNavigateBack: () -> Unit,
     onNavigateToPlayback: (RecordingData) -> Unit,
+    onPlayAll: (List<RecordingData>, Int) -> Unit,
     onAddRecording: (UUID) -> Unit,
     onRemoveRecording: (UUID) -> Unit,
+    onReorder: (Int, Int) -> Unit,
     colorScheme: ColorScheme
 ) {
     var showAddRecordingSheet by remember { mutableStateOf(false) }
@@ -65,6 +80,11 @@ fun PlaylistDetailScreen(
     val recordingsInPlaylist = state.recordings.map { it.uuid }.toSet()
     val availableRecordings = allRecordings.filter { it.uuid !in recordingsInPlaylist }
 
+    // Drag and drop state
+    var draggedItemIndex by remember { mutableIntStateOf(-1) }
+    var dragOffset by remember { mutableFloatStateOf(0f) }
+    val listState = rememberLazyListState()
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -72,6 +92,13 @@ fun PlaylistDetailScreen(
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    if (state.recordings.isNotEmpty()) {
+                        IconButton(onClick = { onPlayAll(state.recordings, 0) }) {
+                            Icon(Icons.Default.PlayArrow, contentDescription = "Play All")
+                        }
                     }
                 }
             )
@@ -125,14 +152,36 @@ fun PlaylistDetailScreen(
                 }
             } else {
                 LazyColumn(
+                    state = listState,
                     contentPadding = PaddingValues(16.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    items(state.recordings) { recording ->
-                        PlaylistRecordingItem(
+                    itemsIndexed(state.recordings, key = { _, item -> item.uuid ?: item.title }) { index, recording ->
+                        val isDragging = draggedItemIndex == index
+                        DraggablePlaylistRecordingItem(
                             recording = recording,
-                            onItemClick = { onNavigateToPlayback(recording) },
-                            onRemoveClick = { recording.uuid?.let { onRemoveRecording(it) } }
+                            index = index,
+                            isDragging = isDragging,
+                            dragOffset = if (isDragging) dragOffset else 0f,
+                            onItemClick = { onPlayAll(state.recordings, index) },
+                            onRemoveClick = { recording.uuid?.let { onRemoveRecording(it) } },
+                            onDragStart = { draggedItemIndex = index },
+                            onDrag = { delta ->
+                                dragOffset += delta
+                                // Calculate target index based on drag offset
+                                val itemHeight = 80.dp.value // Approximate item height
+                                val targetIndex = (index + (dragOffset / itemHeight).roundToInt())
+                                    .coerceIn(0, state.recordings.size - 1)
+                                if (targetIndex != draggedItemIndex && targetIndex != index) {
+                                    onReorder(draggedItemIndex, targetIndex)
+                                    draggedItemIndex = targetIndex
+                                    dragOffset = 0f
+                                }
+                            },
+                            onDragEnd = {
+                                draggedItemIndex = -1
+                                dragOffset = 0f
+                            }
                         )
                     }
                 }
@@ -155,6 +204,103 @@ fun PlaylistDetailScreen(
                     }
                 }
             )
+        }
+    }
+}
+
+@Composable
+fun DraggablePlaylistRecordingItem(
+    recording: RecordingData,
+    index: Int,
+    isDragging: Boolean,
+    dragOffset: Float,
+    onItemClick: () -> Unit,
+    onRemoveClick: () -> Unit,
+    onDragStart: () -> Unit,
+    onDrag: (Float) -> Unit,
+    onDragEnd: () -> Unit
+) {
+    val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd")
+    val formattedDate = recording.creationDate.format(formatter)
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .offset { IntOffset(0, dragOffset.roundToInt()) }
+            .zIndex(if (isDragging) 1f else 0f)
+            .graphicsLayer {
+                shadowElevation = if (isDragging) 8f else 0f
+            }
+            .background(
+                if (isDragging) MaterialTheme.colorScheme.surfaceVariant
+                else MaterialTheme.colorScheme.surface
+            )
+            .clickable { onItemClick() }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Drag handle
+            Icon(
+                imageVector = Icons.Default.DragHandle,
+                contentDescription = "Drag to reorder",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .padding(end = 8.dp)
+                    .pointerInput(Unit) {
+                        detectDragGesturesAfterLongPress(
+                            onDragStart = { onDragStart() },
+                            onDrag = { change, dragAmount ->
+                                change.consume()
+                                onDrag(dragAmount.y)
+                            },
+                            onDragEnd = { onDragEnd() },
+                            onDragCancel = { onDragEnd() }
+                        )
+                    }
+            )
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = recording.title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = formattedDate,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = "•",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = recording.duration.formatTime(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            IconButton(onClick = onRemoveClick) {
+                Icon(
+                    imageVector = Icons.Default.Remove,
+                    contentDescription = "Remove from playlist",
+                    tint = MaterialTheme.colorScheme.error
+                )
+            }
         }
     }
 }

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/playlist/PlaylistViewModel.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/playlist/PlaylistViewModel.kt
@@ -90,6 +90,26 @@ class PlaylistDetailViewModel(
             repository.addRecordingToPlaylist(playlistUuid, recordingUuid)
         }
     }
+
+    fun reorderRecordings(fromIndex: Int, toIndex: Int) {
+        val currentRecordings = _uiState.value.recordings.toMutableList()
+        if (fromIndex < 0 || fromIndex >= currentRecordings.size ||
+            toIndex < 0 || toIndex >= currentRecordings.size) {
+            return
+        }
+
+        val item = currentRecordings.removeAt(fromIndex)
+        currentRecordings.add(toIndex, item)
+
+        // Update UI immediately
+        _uiState.value = _uiState.value.copy(recordings = currentRecordings)
+
+        // Persist to database
+        viewModelScope.launch {
+            val recordingUuids = currentRecordings.mapNotNull { it.uuid }
+            repository.reorderRecordings(playlistUuid, recordingUuids)
+        }
+    }
 }
 
 data class PlaylistDetailUiState(


### PR DESCRIPTION
- Add drag & drop reordering support for playlist items
  - Long press on drag handle to reorder
  - Position persisted to database

- Add repeat mode support (off, single, all)
  - Toggle between modes with repeat button
  - Visual indicator for current mode

- Add shuffle mode for playlist playback
  - Maintains current track when enabling shuffle
  - Re-shuffles on each toggle

- Add sequential playlist playback
  - Auto-play next track on completion
  - Previous/Next track navigation
  - 3-second threshold for previous (restart vs previous track)

- Update PlaybackScreen with new controls
  - Shuffle and repeat toggle buttons
  - Previous/Next track buttons
  - Track position indicator (N / Total)

- Update PlaylistDetailScreen
  - Play All button in toolbar
  - Draggable recording items with handle
  - Click to play from specific position

Implements tasks 3 & 4 from Android development plan:
- Basic playlist functionality
- Extended playlist features (D&D, repeat, shuffle)