### PR TITLE
feat(ios): Automate dSYM upload to Firebase Crashlytics during build

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,6 +26,48 @@ platform :ios do
     )
   end
 
+  # dSYMをFirebase Crashlyticsにアップロード
+  desc "Download dSYMs from App Store Connect and upload to Firebase Crashlytics"
+  lane :upload_dsyms do |options|
+    version = options[:version] || "latest"
+
+    UI.message("Downloading dSYMs for version: #{version}")
+
+    # App Store Connectから最新のdSYMをダウンロード
+    download_dsyms(
+      app_identifier: "com.entaku.VoiLog",
+      version: version
+    )
+
+    # Firebase Crashlyticsにアップロード
+    # Note: Firebase CLI must be installed: brew install firebase-cli
+    # Or use the upload-symbols binary from the Firebase SDK
+    upload_symbols_to_crashlytics(
+      gsp_path: "ios/VoiLog/GoogleService-Info.plist"
+    )
+
+    # ダウンロードしたdSYMファイルを削除
+    clean_build_artifacts
+
+    UI.success("dSYMs uploaded to Firebase Crashlytics successfully!")
+  end
+
+  # 特定のバージョンのdSYMをアップロード
+  desc "Upload dSYMs for a specific app version"
+  lane :upload_dsyms_for_version do |options|
+    version = options[:version]
+    UI.user_error!("Please specify a version: fastlane upload_dsyms_for_version version:1.3.1") unless version
+    upload_dsyms(version: version)
+  end
+
+  # リリース後のdSYMアップロード（App Store Connectでの処理完了後に実行）
+  desc "Upload dSYMs after App Store Connect processing is complete"
+  lane :post_release_dsyms do
+    UI.important("Note: Run this lane after App Store Connect has finished processing the build.")
+    UI.important("This typically takes 15-30 minutes after upload.")
+    upload_dsyms
+  end
+
   # メタデータとスクリーンショットのアップロード、審査提出
   desc "Upload metadata and screenshots to App Store Connect and submit for review"
   lane :upload_metadata do

--- a/ios/VoiLog.xcodeproj/project.pbxproj
+++ b/ios/VoiLog.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 				619799DF28C34A2500169FB6 /* Frameworks */,
 				619799E028C34A2500169FB6 /* Resources */,
 				61458CE22C4B939400B7107E /* Embed Foundation Extensions */,
+				61DSYM0028F30B4700BF337E /* Upload dSYM to Firebase Crashlytics */,
 			);
 			buildRules = (
 			);
@@ -393,6 +394,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\n  swiftlint --fix \n  swiftlint\nelse\n  echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		61DSYM0028F30B4700BF337E /* Upload dSYM to Firebase Crashlytics */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Upload dSYM to Firebase Crashlytics";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Firebase Crashlytics dSYM Upload Script\n# Only upload for Release builds to avoid unnecessary uploads during development\nif [ \"${CONFIGURATION}\" = \"Release\" ]; then\n  echo \"Uploading dSYM to Firebase Crashlytics...\"\n  \n  # Path to the Firebase Crashlytics run script (SPM)\n  FIREBASE_SCRIPT=\"${BUILD_DIR%/Build/*}/SourcePackages/artifacts/firebase-ios-sdk/FirebaseCrashlytics/run\"\n  \n  if [ -f \"$FIREBASE_SCRIPT\" ]; then\n    \"$FIREBASE_SCRIPT\"\n    echo \"dSYM upload completed.\"\n  else\n    echo \"warning: Firebase Crashlytics run script not found at: $FIREBASE_SCRIPT\"\n    echo \"warning: dSYM will not be automatically uploaded. Use 'bundle exec fastlane upload_dsyms' manually.\"\n  fi\nelse\n  echo \"Skipping dSYM upload for ${CONFIGURATION} build.\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
- Add Xcode Build Phase script to automatically upload dSYM files
- Only uploads during Release builds to avoid unnecessary debug uploads
- Add Fastlane lanes for manual dSYM upload from App Store Connect:
  - upload_dsyms: Download and upload latest dSYMs
  - upload_dsyms_for_version: Upload dSYMs for specific version
  - post_release_dsyms: Upload dSYMs after App Store processing

https://claude.ai/code/session_01ByBTedR9rEHaLHGf8qwMcJ