### PR TITLE
fix: AppIconSettingView の PurchaseManager.shared 直接参照を排除 (#144)

### DIFF
--- a/ios/VoiLog/Setting/AppIconSettingView.swift
+++ b/ios/VoiLog/Setting/AppIconSettingView.swift
@@ -13,6 +13,10 @@ import ComposableArchitecture
 struct AppIconSettingView: View {
     @Perception.Bindable var store: StoreOf<AppIconFeature>
 
+    /// 課金処理は Singleton を直接参照せず TCA Dependency 経由で注入する。
+    /// テスト・Preview では `previewValue` / `testValue`（MockPurchaseManager）が解決される。
+    @Dependency(\.purchaseManager) var purchaseManager
+
     private let columns = [
         GridItem(.flexible()),
         GridItem(.flexible()),
@@ -32,7 +36,7 @@ struct AppIconSettingView: View {
 
             if !store.hasPurchasedPremium {
                 Section {
-                    NavigationLink(destination: PaywallView(purchaseManager: PurchaseManager.shared)) {
+                    NavigationLink(destination: PaywallView(purchaseManager: purchaseManager)) {
                         HStack(spacing: 12) {
                             Image(systemName: "crown.fill")
                                 .foregroundStyle(.yellow)

--- a/ios/VoiLog/Store/PurchaseManager.swift
+++ b/ios/VoiLog/Store/PurchaseManager.swift
@@ -1,6 +1,7 @@
 import StoreKit
 import RevenueCat
 import os.log
+import Dependencies
 
 protocol PurchaseManagerProtocol {
     func fetchProPlan() async throws -> (name: String, price: String)
@@ -146,6 +147,23 @@ class PurchaseManager: PurchaseManagerProtocol {
         }
 
         os_log("=== One Time Purchase End ===", log: logger, type: .debug)
+    }
+}
+
+// MARK: - PurchaseManager Dependency
+
+private enum PurchaseManagerKey: DependencyKey {
+    static let liveValue: PurchaseManagerProtocol = PurchaseManager.shared
+    static let previewValue: PurchaseManagerProtocol = MockPurchaseManager()
+    static let testValue: PurchaseManagerProtocol = MockPurchaseManager()
+}
+
+extension DependencyValues {
+    /// 課金処理（RevenueCat ラッパー）への依存。
+    /// View / Reducer から `PurchaseManager.shared` を直接参照せず、これ経由で注入する。
+    var purchaseManager: PurchaseManagerProtocol {
+        get { self[PurchaseManagerKey.self] }
+        set { self[PurchaseManagerKey.self] = newValue }
     }
 }
 

--- a/ios/VoiLogTests/AppIconFeatureTests.swift
+++ b/ios/VoiLogTests/AppIconFeatureTests.swift
@@ -249,6 +249,34 @@ final class AppIconFeatureTests: XCTestCase {
         XCTAssertEqual(capturedIconName, "AppIcon_Green")
     }
 
+    // MARK: - PurchaseManager Dependency Tests
+
+    /// Issue #144: AppIconSettingView が `PurchaseManager.shared` を直接参照する代わりに
+    /// TCA Dependency 経由で課金処理を取得できる（=モック化できる）ことを検証する。
+    func test_purchaseManagerDependency_canBeOverriddenWithMock() {
+        let mock = MockPurchaseManager(productName: "Test Plan", productPrice: "¥980")
+        withDependencies {
+            $0.purchaseManager = mock
+        } operation: {
+            @Dependency(\.purchaseManager) var purchaseManager
+            XCTAssertTrue(
+                purchaseManager is MockPurchaseManager,
+                "テスト/Preview ではモックに差し替えられる必要がある"
+            )
+        }
+    }
+
+    /// テストコンテキストでは既定値（testValue = MockPurchaseManager）が解決され、
+    /// 本物の `PurchaseManager.shared` が初期化されないことを検証する。
+    func test_purchaseManagerDependency_defaultsToMockInTestContext() {
+        withDependencies { _ in
+            // 既定値を上書きせず testValue を解決させる
+        } operation: {
+            @Dependency(\.purchaseManager) var purchaseManager
+            XCTAssertTrue(purchaseManager is MockPurchaseManager)
+        }
+    }
+
     // MARK: - AppIcon Enum Tests
 
     func test_appIcon_isPremiumReturnsFalseForDefault() {


### PR DESCRIPTION
## 対応issue
Closes #144

`AppIconSettingView` が TCA Store を使いながら `PurchaseManager.shared` をビュー内で直接参照しており、「TCA Dependency Injection による状態管理の一元化」原則に違反していた問題を解消する。

## 変更内容
- **`Store/PurchaseManager.swift`**: `PurchaseManagerProtocol` を TCA Dependency として登録する `DependencyKey` を追加。
  - `liveValue = PurchaseManager.shared`
  - `previewValue = MockPurchaseManager()`
  - `testValue = MockPurchaseManager()`
- **`Setting/AppIconSettingView.swift`**: `PurchaseManager.shared` 直接参照を排除し、`@Dependency(\.purchaseManager)` 経由で取得して `PaywallView` に注入。
- **`VoiLogTests/AppIconFeatureTests.swift`**: 依存をモックに差し替えられること／テストコンテキストで `MockPurchaseManager` が解決されることを検証するテストを2件追加。

これにより、
- ✅ ペイウォール用の課金処理をモック化できる（テスト不能の解消）
- ✅ Preview 環境では `previewValue`（Mock）が解決され、本物の `PurchaseManager` が初期化されない（Preview 破損の解消）
- ✅ Singleton への直接依存を排し、依存注入に一元化

### スコープ判断（最小変更）
issue の改善提案には「`@PresentationState` + `PaywallFeature` でペイウォール遷移を TCA 管理する」案も挙がっていたが、`PaywallView` は現状 TCA Reducer を持たない大きなビューであり、`PaywallFeature` の新規作成は本issueのスコープを大きく超える。今回は **「`PurchaseManager.shared` 直接参照の排除＝依存注入」** という核心要件に絞り、ナビゲーションは既存の `NavigationLink` を維持した（後述の理由も参照）。

## ハーネス検証結果
- ビルド: ✅
- テスト: ✅（追加2件含む `AppIconFeatureTests` の本機能テストはすべてパス）
- Lint: ✅（`swiftlint` serious violations 0件。残る warning はすべて既存のもの）

## 人間に確認してほしい点
- **既存の Perception フレーク（本PRとは無関係）**: `VoiLogTests/AppIconFeatureTests` 実行時に、稀に `PerceptionRegistrar.swift:223: Perceptible state was accessed but is not being tracked` という失敗が、毎回違う非同期テスト（実行に約2秒かかるもの）に attribute されて発生する。
  - **調査結果**: `main`（本PRの変更なし）でも **4回中3回** 同じ失敗が再現し、本PRの変更（最小・既存ビューと同じ perceptible state アクセス）では発生率は変わらない。テストホストアプリ起動時の SwiftUI レンダリング（`@Perception.Bindable` 系ビュー）に起因する **既存の環境依存フレーク** と判断。本PRが原因ではない。
  - 別issueとして「テストホストの Perception 警告（`WithPerceptionTracking` 不足）」を切り出して対応するのが望ましい。
- 当初 reducer 駆動の `navigationDestination(isPresented:)` でペイウォール遷移をTCA管理する案も実装したが、`$store` バインディングの getter が tracking 外で評価され Perception 警告を**確実に**誘発したため取り下げた（`PaywallFeature` 化が必要でスコープ外）。今回の `@Dependency` 注入はこの問題を起こさず、issue の核心要件を満たす。

---
*このPRは resolve-issues スキルにより作成されました*