### PR TITLE
fix: XCTest 実行時にアプリ UI を描画せず Perception テストフレークを解消 (#147)

### DIFF
--- a/ios/VoiLog/VoiceMemoApp.swift
+++ b/ios/VoiLog/VoiceMemoApp.swift
@@ -81,6 +81,15 @@ struct VoiceMemoApp: App {
 
     private let backgroundTaskManager = BackgroundTaskManager()
 
+    /// ユニットテスト（XCTest）実行中かどうか。
+    /// テストホストは VoiLog.app 本体のため、テスト時にアプリ UI を描画すると
+    /// `@Perception.Bindable` を使うビューが `WithPerceptionTracking` 外で
+    /// 評価され、`PerceptionRegistrar` 警告が非同期テストに紐づいて間欠失敗する (#147)。
+    /// テスト時は UI を描画しないことでこのフレークを防ぐ。
+    private var isRunningUnitTests: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
     init() {
         let environmentConfig = loadEnvironmentVariables()
         self.admobUnitId = environmentConfig.admobKey
@@ -101,7 +110,10 @@ struct VoiceMemoApp: App {
 
     var body: some Scene {
         WindowGroup {
-            if showSplash {
+            if isRunningUnitTests {
+                // ユニットテスト時はアプリ UI を描画しない（#147 のフレーク対策）
+                EmptyView()
+            } else if showSplash {
                 SplashView {
                     withAnimation {
                         showSplash = false


### PR DESCRIPTION
## 対応issue
Closes #147

## 根本原因
`VoiLogTests` のテストホストは `VoiLog.app` 本体（`TEST_HOST` 設定）。そのためユニットテスト実行中もアプリの `@main`（`VoiceMemoApp`）が起動し、ルート UI（`VoiceAppView` 配下）が描画される。

コードベースの **12 ファイルが `@Perception.Bindable` を使うが、`WithPerceptionTracking` で `body` を包んでいるのは 2 ファイルのみ**。包まれていないビューが非同期テストの待機中（run loop が回るタイミング）にレンダリングされると、`PerceptionRegistrar.swift:223: Perceptible state was accessed but is not being tracked` 警告がグローバルに発火し、**実行中の約2秒の非同期テストに attribute されて間欠失敗**していた。

## 変更内容
`VoiceMemoApp.body` で XCTest 実行中（`ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil`）を判定し、その場合は `WindowGroup` の中身を `EmptyView()` にしてルート UI を描画しない。

- ユニットテストはアプリ UI を必要としない（TCA TestStore はビュー非依存）ため副作用なし。
- 1 ファイル・約12行の最小変更。テスト時の挙動のみに影響し、製品ビルドの挙動は不変。

## ハーネス検証結果
- ビルド: ✅
- Lint: ✅（`VoiceMemoApp.swift` の serious 0件。残る warning は既存の `AppDelegate` シグネチャ由来で本変更と無関係）
- テスト（フレーク対象 `AppIconFeatureTests`）:

| 対象 | 結果 |
|---|---|
| **main**（変更前） | 連続実行で約75%失敗（`PerceptionRegistrar`） |
| **本PR** | **4/4 成功**。失敗していたテストの実行時間も ~2s → <0.05s に短縮 |

## 人間に確認してほしい点
- **本PRとは無関係の既存テスト失敗**: 全 `VoiLogTests` を流すと `TranscriptionFeatureTests` の3件（`testStartTapped_*Failure_setsStatusFailed`）が失敗する。これは `main`（本変更なし）でも同一に失敗する**既存の問題**（`.failed(...)` のエラーメッセージ文字列の期待値ズレ。ロケール依存の可能性）であり、本issue/本PRのスコープ外。別途対応が必要。
- 判定に `XCTestConfigurationFilePath` 環境変数を使用。UI テスト（`VoiLogUITests`）は別プロセスのため影響しないが、もし将来テストホスト上で UI を描画する必要が出た場合はこの判定を見直す必要がある。

---
*このPRは resolve-issues スキルにより作成されました*