### PR TITLE
feat(android): 年額プラン（7日間無料トライアル付き）を追加

### DIFF
--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/store/BillingRepository.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/store/BillingRepository.kt
@@ -7,6 +7,7 @@ import com.entaku.simpleRecord.BuildConfig
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
@@ -16,10 +17,17 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+enum class PlanType {
+    MONTHLY,
+    ANNUAL,
+    OTHER
+}
+
 data class PremiumProduct(
     val productId: String,
     val title: String,
     val price: String,
+    val planType: PlanType,
     val rcPackage: Package
 )
 
@@ -63,6 +71,11 @@ class BillingRepository internal constructor(
                         productId = pkg.product.id,
                         title = pkg.product.title,
                         price = pkg.product.price.formatted,
+                        planType = when (pkg.packageType) {
+                            PackageType.MONTHLY -> PlanType.MONTHLY
+                            PackageType.ANNUAL -> PlanType.ANNUAL
+                            else -> PlanType.OTHER
+                        },
                         rcPackage = pkg
                     )
                 }

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/store/PaywallScreen.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/store/PaywallScreen.kt
@@ -20,7 +20,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,7 +34,10 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -169,6 +174,90 @@ private fun PremiumFeatureList() {
 }
 
 @Composable
+private fun PlanSelector(
+    monthly: PremiumProduct,
+    annual: PremiumProduct,
+    isAnnualSelected: Boolean,
+    onSelect: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        PlanButton(
+            titleRes = R.string.premium_plan_annual,
+            priceText = stringResource(R.string.premium_price_per_year, annual.price),
+            badgeRes = R.string.premium_deal_badge,
+            selected = isAnnualSelected,
+            onClick = { onSelect(true) },
+            modifier = Modifier.weight(1f)
+        )
+        PlanButton(
+            titleRes = R.string.premium_plan_monthly,
+            priceText = stringResource(R.string.premium_price_per_month, monthly.price),
+            badgeRes = null,
+            selected = !isAnnualSelected,
+            onClick = { onSelect(false) },
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun PlanButton(
+    titleRes: Int,
+    priceText: String,
+    badgeRes: Int?,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier,
+        border = BorderStroke(
+            width = if (selected) 2.dp else 1.dp,
+            color = if (selected) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.outline
+            }
+        ),
+        colors = ButtonDefaults.outlinedButtonColors(
+            containerColor = if (selected) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surface
+            }
+        )
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(vertical = 8.dp)
+        ) {
+            if (badgeRes != null) {
+                Text(
+                    stringResource(badgeRes),
+                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Spacer(Modifier.height(2.dp))
+            }
+            Text(
+                stringResource(titleRes),
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                priceText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
 private fun BillingContent(
     billingState: BillingState,
     billingManager: BillingRepository
@@ -202,12 +291,30 @@ private fun BillingContent(
             }
         }
         is BillingState.Ready -> {
-            val product = state.products.firstOrNull()
-            if (product != null) {
+            val monthly = state.products.firstOrNull { it.planType == PlanType.MONTHLY }
+                ?: state.products.firstOrNull()
+            val annual = state.products.firstOrNull { it.planType == PlanType.ANNUAL }
+            if (monthly != null) {
+                // 年額パッケージがofferingに存在する場合のみセレクターを表示する。
+                // 存在しない場合は従来どおり単一プラン（月額）のUIにフォールバックする。
+                var isAnnualSelected by rememberSaveable(annual != null) {
+                    mutableStateOf(annual != null)
+                }
+                val selectedProduct = if (isAnnualSelected && annual != null) annual else monthly
+
+                if (annual != null) {
+                    PlanSelector(
+                        monthly = monthly,
+                        annual = annual,
+                        isAnnualSelected = isAnnualSelected,
+                        onSelect = { isAnnualSelected = it }
+                    )
+                    Spacer(Modifier.height(16.dp))
+                }
                 Button(
                     onClick = {
                         if (activity != null) {
-                            billingManager.launchPurchaseFlow(activity, product)
+                            billingManager.launchPurchaseFlow(activity, selectedProduct)
                         } else {
                             android.util.Log.e("BillingContent", "Activity is null — cannot launch purchase flow")
                         }
@@ -220,14 +327,28 @@ private fun BillingContent(
                             style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
                         )
                         Text(
-                            stringResource(R.string.premium_trial_then_price, product.price),
+                            stringResource(
+                                if (selectedProduct.planType == PlanType.ANNUAL) {
+                                    R.string.premium_trial_then_price_annual
+                                } else {
+                                    R.string.premium_trial_then_price
+                                },
+                                selectedProduct.price
+                            ),
                             style = MaterialTheme.typography.bodySmall
                         )
                     }
                 }
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    stringResource(R.string.premium_trial_terms, product.price),
+                    stringResource(
+                        if (selectedProduct.planType == PlanType.ANNUAL) {
+                            R.string.premium_trial_terms_annual
+                        } else {
+                            R.string.premium_trial_terms
+                        },
+                        selectedProduct.price
+                    ),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center

--- a/android/simpleRecord/app/src/main/res/values-de/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-de/strings.xml
@@ -146,6 +146,13 @@
     <string name="premium_free_trial">7 Tage kostenlos testen</string>
     <string name="premium_trial_then_price">Dann %s / Monat (automatische Verlängerung)</string>
     <string name="premium_trial_terms">Nach der 7-tägigen kostenlosen Testphase werden %s/Monat berechnet. Sie können jederzeit in den Google Play-Abonnementeinstellungen vor dem Verlängerungsdatum kündigen.</string>
+    <string name="premium_plan_monthly">Monatlich</string>
+    <string name="premium_plan_annual">Jährlich</string>
+    <string name="premium_deal_badge">Bestes Angebot</string>
+    <string name="premium_price_per_month">%s / Monat</string>
+    <string name="premium_price_per_year">%s / Jahr</string>
+    <string name="premium_trial_then_price_annual">Danach %s / Jahr, verlängert sich automatisch</string>
+    <string name="premium_trial_terms_annual">Nach der 7-tägigen kostenlosen Testphase werden %s/Jahr berechnet. Jederzeit vor dem Verlängerungsdatum in den Google Play-Aboeinstellungen kündbar.</string>
 
     <!-- Transcription -->
     <string name="transcription_title">Transkription</string>

--- a/android/simpleRecord/app/src/main/res/values-es/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-es/strings.xml
@@ -146,6 +146,13 @@
     <string name="premium_free_trial">Prueba gratis 7 días</string>
     <string name="premium_trial_then_price">Luego %s / mes (renovación automática)</string>
     <string name="premium_trial_terms">Después de la prueba gratuita de 7 días, se cobrará %s/mes. Cancela en cualquier momento en la configuración de suscripciones de Google Play antes de la fecha de renovación.</string>
+    <string name="premium_plan_monthly">Mensual</string>
+    <string name="premium_plan_annual">Anual</string>
+    <string name="premium_deal_badge">Mejor oferta</string>
+    <string name="premium_price_per_month">%s / mes</string>
+    <string name="premium_price_per_year">%s / año</string>
+    <string name="premium_trial_then_price_annual">Después %s / año, se renueva automáticamente</string>
+    <string name="premium_trial_terms_annual">Tras la prueba gratuita de 7 días, se te cobrará %s/año. Cancela cuando quieras en los ajustes de suscripciones de Google Play antes de la fecha de renovación.</string>
 
     <!-- Transcription -->
     <string name="transcription_title">Transcripción</string>

--- a/android/simpleRecord/app/src/main/res/values-fr/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-fr/strings.xml
@@ -146,6 +146,13 @@
     <string name="premium_free_trial">Essai gratuit 7 jours</string>
     <string name="premium_trial_then_price">Puis %s / mois (renouvellement automatique)</string>
     <string name="premium_trial_terms">Après l\'essai gratuit de 7 jours, %s/mois vous seront facturés. Annulez à tout moment dans les paramètres d\'abonnement Google Play avant la date de renouvellement.</string>
+    <string name="premium_plan_monthly">Mensuel</string>
+    <string name="premium_plan_annual">Annuel</string>
+    <string name="premium_deal_badge">Meilleure offre</string>
+    <string name="premium_price_per_month">%s / mois</string>
+    <string name="premium_price_per_year">%s / an</string>
+    <string name="premium_trial_then_price_annual">Ensuite %s / an, renouvellement automatique</string>
+    <string name="premium_trial_terms_annual">Après l\'essai gratuit de 7 jours, %s/an vous sera facturé. Annulable à tout moment dans les paramètres d\'abonnement Google Play avant la date de renouvellement.</string>
 
     <!-- Transcription -->
     <string name="transcription_title">Transcription</string>

--- a/android/simpleRecord/app/src/main/res/values-it/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-it/strings.xml
@@ -146,6 +146,13 @@
     <string name="premium_free_trial">Prova gratis 7 giorni</string>
     <string name="premium_trial_then_price">Poi %s / mese (rinnovo automatico)</string>
     <string name="premium_trial_terms">Dopo la prova gratuita di 7 giorni, verranno addebitati %s/mese. Annulla in qualsiasi momento nelle impostazioni abbonamenti di Google Play prima della data di rinnovo.</string>
+    <string name="premium_plan_monthly">Mensile</string>
+    <string name="premium_plan_annual">Annuale</string>
+    <string name="premium_deal_badge">Più conveniente</string>
+    <string name="premium_price_per_month">%s / mese</string>
+    <string name="premium_price_per_year">%s / anno</string>
+    <string name="premium_trial_then_price_annual">Poi %s / anno, si rinnova automaticamente</string>
+    <string name="premium_trial_terms_annual">Dopo la prova gratuita di 7 giorni, ti verranno addebitati %s/anno. Annulla in qualsiasi momento nelle impostazioni degli abbonamenti di Google Play prima della data di rinnovo.</string>
 
     <!-- Transcription -->
     <string name="transcription_title">Trascrizione</string>

--- a/android/simpleRecord/app/src/main/res/values-ja/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-ja/strings.xml
@@ -109,6 +109,13 @@
     <string name="premium_free_trial">7日間無料で試す</string>
     <string name="premium_trial_then_price">その後 %s /月（自動更新）</string>
     <string name="premium_trial_terms">7日間の無料トライアル終了後、%s/月で自動的に課金されます。更新日の24時間前までにGoogle Playのサブスクリプション設定からいつでもキャンセルできます。</string>
+    <string name="premium_plan_monthly">月額</string>
+    <string name="premium_plan_annual">年額</string>
+    <string name="premium_deal_badge">お得</string>
+    <string name="premium_price_per_month">%s /月</string>
+    <string name="premium_price_per_year">%s /年</string>
+    <string name="premium_trial_then_price_annual">その後 %s /年（自動更新）</string>
+    <string name="premium_trial_terms_annual">7日間の無料トライアル終了後、%s/年で自動的に課金されます。更新日の24時間前までにGoogle Playのサブスクリプション設定からいつでもキャンセルできます。</string>
 
     <!-- Recording Presets -->
     <string name="preset_label">プリセット</string>

--- a/android/simpleRecord/app/src/main/res/values-pt/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-pt/strings.xml
@@ -146,6 +146,13 @@
     <string name="premium_free_trial">Experimente grátis por 7 dias</string>
     <string name="premium_trial_then_price">Depois %s / mês (renovação automática)</string>
     <string name="premium_trial_terms">Após o período de teste gratuito de 7 dias, será cobrado %s/mês. Cancele a qualquer momento nas configurações de assinatura do Google Play antes da data de renovação.</string>
+    <string name="premium_plan_monthly">Mensal</string>
+    <string name="premium_plan_annual">Anual</string>
+    <string name="premium_deal_badge">Melhor oferta</string>
+    <string name="premium_price_per_month">%s / mês</string>
+    <string name="premium_price_per_year">%s / ano</string>
+    <string name="premium_trial_then_price_annual">Depois %s / ano, renovação automática</string>
+    <string name="premium_trial_terms_annual">Após o período de teste gratuito de 7 dias, será cobrado %s/ano. Cancele a qualquer momento nas definições de subscrição do Google Play antes da data de renovação.</string>
 
     <!-- Transcription -->
     <string name="transcription_title">Transcrição</string>

--- a/android/simpleRecord/app/src/main/res/values-ru/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-ru/strings.xml
@@ -146,6 +146,13 @@
     <string name="premium_free_trial">Попробовать бесплатно 7 дней</string>
     <string name="premium_trial_then_price">Затем %s / месяц (автообновление)</string>
     <string name="premium_trial_terms">После 7-дневного бесплатного пробного периода будет списываться %s/месяц. Отменить можно в любое время в настройках подписок Google Play до даты продления.</string>
+    <string name="premium_plan_monthly">Ежемесячно</string>
+    <string name="premium_plan_annual">Ежегодно</string>
+    <string name="premium_deal_badge">Выгодно</string>
+    <string name="premium_price_per_month">%s / месяц</string>
+    <string name="premium_price_per_year">%s / год</string>
+    <string name="premium_trial_then_price_annual">Затем %s / год, автопродление</string>
+    <string name="premium_trial_terms_annual">После 7-дневного бесплатного периода будет списываться %s/год. Отменить можно в любой момент в настройках подписок Google Play до даты продления.</string>
 
     <!-- Transcription -->
     <string name="transcription_title">Транскрипция</string>

--- a/android/simpleRecord/app/src/main/res/values-tr/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-tr/strings.xml
@@ -146,6 +146,13 @@
     <string name="premium_free_trial">7 Gün Ücretsiz Dene</string>
     <string name="premium_trial_then_price">Ardından %s / ay (otomatik yenileme)</string>
     <string name="premium_trial_terms">7 günlük ücretsiz deneme süresinin ardından aylık %s ücretlendirileceksiniz. Google Play abonelik ayarlarından yenileme tarihinden önce istediğiniz zaman iptal edebilirsiniz.</string>
+    <string name="premium_plan_monthly">Aylık</string>
+    <string name="premium_plan_annual">Yıllık</string>
+    <string name="premium_deal_badge">En avantajlı</string>
+    <string name="premium_price_per_month">%s / ay</string>
+    <string name="premium_price_per_year">%s / yıl</string>
+    <string name="premium_trial_then_price_annual">Sonrasında %s / yıl, otomatik yenilenir</string>
+    <string name="premium_trial_terms_annual">7 günlük ücretsiz deneme sonrasında %s/yıl ücretlendirilirsiniz. Yenileme tarihinden önce Google Play abonelik ayarlarından istediğiniz zaman iptal edebilirsiniz.</string>
 
     <!-- Transcription -->
     <string name="transcription_title">Transkripsiyon</string>

--- a/android/simpleRecord/app/src/main/res/values-vi/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-vi/strings.xml
@@ -146,6 +146,13 @@
     <string name="premium_free_trial">Dùng thử miễn phí 7 ngày</string>
     <string name="premium_trial_then_price">Sau đó %s / tháng (tự động gia hạn)</string>
     <string name="premium_trial_terms">Sau thời gian dùng thử miễn phí 7 ngày, bạn sẽ bị tính phí %s/tháng. Hủy bất cứ lúc nào trong cài đặt đăng ký Google Play trước ngày gia hạn.</string>
+    <string name="premium_plan_monthly">Hàng tháng</string>
+    <string name="premium_plan_annual">Hàng năm</string>
+    <string name="premium_deal_badge">Tiết kiệm nhất</string>
+    <string name="premium_price_per_month">%s / tháng</string>
+    <string name="premium_price_per_year">%s / năm</string>
+    <string name="premium_trial_then_price_annual">Sau đó %s / năm, tự động gia hạn</string>
+    <string name="premium_trial_terms_annual">Sau 7 ngày dùng thử miễn phí, bạn sẽ bị tính phí %s/năm. Hủy bất cứ lúc nào trong cài đặt đăng ký của Google Play trước ngày gia hạn.</string>
 
     <!-- Transcription -->
     <string name="transcription_title">Phiên âm</string>

--- a/android/simpleRecord/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-zh-rCN/strings.xml
@@ -146,6 +146,13 @@
     <string name="premium_free_trial">免费试用7天</string>
     <string name="premium_trial_then_price">之后 %s / 月（自动续费）</string>
     <string name="premium_trial_terms">7天免费试用结束后，将按每月%s收费。可在续费日期前随时在Google Play订阅设置中取消。</string>
+    <string name="premium_plan_monthly">月度</string>
+    <string name="premium_plan_annual">年度</string>
+    <string name="premium_deal_badge">超值</string>
+    <string name="premium_price_per_month">%s / 月</string>
+    <string name="premium_price_per_year">%s / 年</string>
+    <string name="premium_trial_then_price_annual">之后 %s / 年（自动续订）</string>
+    <string name="premium_trial_terms_annual">7天免费试用结束后，将按 %s/年自动扣费。可在续订日期前随时在 Google Play 订阅设置中取消。</string>
 
     <!-- Transcription -->
     <string name="transcription_title">转录</string>

--- a/android/simpleRecord/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-zh-rTW/strings.xml
@@ -146,6 +146,13 @@
     <string name="premium_free_trial">免費試用7天</string>
     <string name="premium_trial_then_price">之後 %s / 月（自動續費）</string>
     <string name="premium_trial_terms">7天免費試用結束後，將按每月%s收費。可在續費日期前隨時在Google Play訂閱設定中取消。</string>
+    <string name="premium_plan_monthly">月度</string>
+    <string name="premium_plan_annual">年度</string>
+    <string name="premium_deal_badge">超值</string>
+    <string name="premium_price_per_month">%s / 月</string>
+    <string name="premium_price_per_year">%s / 年</string>
+    <string name="premium_trial_then_price_annual">之後 %s / 年（自動續訂）</string>
+    <string name="premium_trial_terms_annual">7天免費試用結束後，將按 %s/年自動扣款。可在續訂日期前隨時在 Google Play 訂閱設定中取消。</string>
 
     <!-- Transcription -->
     <string name="transcription_title">轉錄</string>

--- a/android/simpleRecord/app/src/main/res/values/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values/strings.xml
@@ -158,6 +158,13 @@
     <string name="premium_free_trial">Try Free for 7 Days</string>
     <string name="premium_trial_then_price">Then %s / month, auto-renews</string>
     <string name="premium_trial_terms">After the 7-day free trial, you will be charged %s/month. Cancel anytime in Google Play subscription settings before the renewal date.</string>
+    <string name="premium_plan_monthly">Monthly</string>
+    <string name="premium_plan_annual">Annual</string>
+    <string name="premium_deal_badge">Best Value</string>
+    <string name="premium_price_per_month">%s / month</string>
+    <string name="premium_price_per_year">%s / year</string>
+    <string name="premium_trial_then_price_annual">Then %s / year, auto-renews</string>
+    <string name="premium_trial_terms_annual">After the 7-day free trial, you will be charged %s/year. Cancel anytime in Google Play subscription settings before the renewal date.</string>
 
     <!-- Transcription -->
     <string name="transcription_title">Transcription</string>

--- a/android/simpleRecord/app/src/test/java/com/entaku/simpleRecord/store/BillingRepositoryTest.kt
+++ b/android/simpleRecord/app/src/test/java/com/entaku/simpleRecord/store/BillingRepositoryTest.kt
@@ -6,13 +6,17 @@ import androidx.test.core.app.ApplicationProvider
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.EntitlementInfo
 import com.revenuecat.purchases.EntitlementInfos
+import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import io.mockk.every
 import io.mockk.mockk
@@ -119,6 +123,59 @@ class BillingRepositoryTest {
         assertEquals("premium", BillingRepository.PREMIUM_ENTITLEMENT_KEY)
     }
 
+    // --- annual plan tests ---
+
+    @Test
+    fun `fetchOfferings maps monthly and annual packages to plan types`() = runTest {
+        fakePurchasesClient.offeringsResult = OfferingsResult.Success(
+            listOf(
+                fakeRcPackage(PackageType.MONTHLY, "premium_monthly", "¥300"),
+                fakeRcPackage(PackageType.ANNUAL, "premium_annual", "¥2,500")
+            )
+        )
+        repository.connect()
+
+        val state = repository.billingState.value as BillingState.Ready
+        assertEquals(2, state.products.size)
+
+        val monthly = state.products.first { it.planType == PlanType.MONTHLY }
+        assertEquals("premium_monthly", monthly.productId)
+        assertEquals("¥300", monthly.price)
+
+        val annual = state.products.first { it.planType == PlanType.ANNUAL }
+        assertEquals("premium_annual", annual.productId)
+        assertEquals("¥2,500", annual.price)
+    }
+
+    @Test
+    fun `fetchOfferings maps non-subscription package types to OTHER`() = runTest {
+        fakePurchasesClient.offeringsResult = OfferingsResult.Success(
+            listOf(fakeRcPackage(PackageType.LIFETIME, "premium_lifetime", "¥5,000"))
+        )
+        repository.connect()
+
+        val state = repository.billingState.value as BillingState.Ready
+        assertEquals(PlanType.OTHER, state.products.single().planType)
+    }
+
+    @Test
+    fun `launchPurchaseFlow with annual product success updates premium status`() = runTest {
+        fakePurchasesClient.offeringsResult = OfferingsResult.Success(
+            listOf(fakeRcPackage(PackageType.ANNUAL, "premium_annual", "¥2,500"))
+        )
+        fakePurchasesClient.purchaseResult = PurchaseResult.Success
+        repository.connect()
+
+        val annual = (repository.billingState.value as BillingState.Ready)
+            .products.single { it.planType == PlanType.ANNUAL }
+        val activity = mockk<Activity>()
+        repository.launchPurchaseFlow(activity, annual)
+
+        val premiumRepo = PremiumRepository.getInstance(context)
+        assertTrue(premiumRepo.isPremium.value)
+        assertTrue(repository.billingState.value is BillingState.Ready)
+    }
+
     // --- launchPurchaseFlow tests (#143) ---
 
     @Test
@@ -128,7 +185,7 @@ class BillingRepositoryTest {
         repository.connect()
 
         val activity = mockk<Activity>()
-        val product = PremiumProduct("id", "title", "$9.99", mockk())
+        val product = PremiumProduct("id", "title", "$9.99", PlanType.MONTHLY, mockk())
         repository.launchPurchaseFlow(activity, product)
 
         assertEquals(BillingState.Purchasing, repository.billingState.value)
@@ -141,7 +198,7 @@ class BillingRepositoryTest {
         repository.connect()
 
         val activity = mockk<Activity>()
-        val product = PremiumProduct("id", "title", "$9.99", mockk())
+        val product = PremiumProduct("id", "title", "$9.99", PlanType.MONTHLY, mockk())
         repository.launchPurchaseFlow(activity, product)
 
         val premiumRepo = PremiumRepository.getInstance(context)
@@ -156,7 +213,7 @@ class BillingRepositoryTest {
         repository.connect()
 
         val activity = mockk<Activity>()
-        val product = PremiumProduct("id", "title", "$9.99", mockk())
+        val product = PremiumProduct("id", "title", "$9.99", PlanType.MONTHLY, mockk())
         repository.launchPurchaseFlow(activity, product)
 
         // PurchasesError.message は PurchasesErrorCode が返す固定メッセージになるため
@@ -171,7 +228,7 @@ class BillingRepositoryTest {
         repository.connect()
 
         val activity = mockk<Activity>()
-        val product = PremiumProduct("id", "title", "$9.99", mockk())
+        val product = PremiumProduct("id", "title", "$9.99", PlanType.MONTHLY, mockk())
         repository.launchPurchaseFlow(activity, product)
 
         assertTrue(repository.billingState.value is BillingState.Ready)
@@ -200,6 +257,22 @@ sealed class PurchaseResult {
     data class Error(val message: String, val userCancelled: Boolean = false) : PurchaseResult()
 }
 
+// --- Test helpers ---
+
+/** RevenueCat Package のモックを生成する（packageType / product.id / price のみ設定） */
+fun fakeRcPackage(type: PackageType, productId: String, formattedPrice: String): Package {
+    val price = mockk<Price>()
+    every { price.formatted } returns formattedPrice
+    val product = mockk<StoreProduct>()
+    every { product.id } returns productId
+    every { product.title } returns productId
+    every { product.price } returns price
+    val pkg = mockk<Package>()
+    every { pkg.packageType } returns type
+    every { pkg.product } returns product
+    return pkg
+}
+
 // --- Fake PurchasesClient ---
 
 class FakePurchasesClient : PurchasesClient {
@@ -212,7 +285,13 @@ class FakePurchasesClient : PurchasesClient {
         when (val result = offeringsResult) {
             is OfferingsResult.Success -> {
                 val offerings = mockk<Offerings>()
-                every { offerings.current } returns null
+                if (result.packages.isEmpty()) {
+                    every { offerings.current } returns null
+                } else {
+                    val offering = mockk<Offering>()
+                    every { offering.availablePackages } returns result.packages
+                    every { offerings.current } returns offering
+                }
                 callback.onReceived(offerings)
             }
             is OfferingsResult.Failure ->


### PR DESCRIPTION
## 概要

iOS 1.11.0 で追加された年額プランを Android にも実装し、プラットフォーム間の課金機能差分を解消する。

## 変更内容

- **BillingRepository**: RevenueCat の `PackageType` から `PlanType`（MONTHLY / ANNUAL / OTHER）を判別し `PremiumProduct` に付与
- **PaywallScreen**: 月額/年額のプランセレクターを追加（iOS 同様に年額をデフォルト選択、「お得」バッジ表示）
  - offering に年額パッケージが**ない場合は従来の単一プラン UI にフォールバック**するため、Play Console 側の商品追加前にリリースされても安全
- **文言**: 12ロケールに年額プラン関連の7キーを追加（default/ja/de/es/fr/it/pt/ru/tr/vi/zh-rCN/zh-rTW）
- **テスト**: PackageType→PlanType マッピング、OTHER フォールバック、年額購入フローの3件を追加（BillingRepositoryTest 17件全パス）

## 検証

- `./gradlew test` ✅ BUILD SUCCESSFUL（BillingRepositoryTest 17件パス）
- `./gradlew assembleDebug` ✅ BUILD SUCCESSFUL

## リリース前に必要な手動作業

- [ ] Google Play Console で年額サブスクリプション商品を作成（7日間無料トライアル設定込み）
- [ ] RevenueCat ダッシュボードで当該商品を現行 offering の `$rc_annual` パッケージに紐付け（iOS と同一 offering）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPxd5JFrDWyrAcTg5TnjzZ