### PR TITLE
feat(android): AI議事録生成機能を追加（サーバー /minutes エンドポイント含む）

### DIFF
--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/MainActivity.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/MainActivity.kt
@@ -65,11 +65,13 @@ import com.entaku.simpleRecord.settings.TutorialScreen
 import com.entaku.simpleRecord.store.BillingRepository
 import com.entaku.simpleRecord.store.PaywallScreen
 import com.entaku.simpleRecord.store.PremiumRepository
+import com.entaku.simpleRecord.transcription.MeetingMinutesScreen
 import com.entaku.simpleRecord.transcription.TranscriptionScreen
 import com.entaku.simpleRecord.transcription.TranscriptionViewModelFactory
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.UUID
 
 // Bottom navigation destinations
@@ -429,7 +431,33 @@ fun AppNavHost() {
                             scope.launch(Dispatchers.IO) {
                                 repository.updateTranscription(id, text)
                             }
+                        },
+                        onNavigateToMeetingMinutes = { id, text ->
+                            // 議事録画面はDBの transcription_text を読むため、保存完了を待ってから遷移する
+                            scope.launch {
+                                withContext(Dispatchers.IO) {
+                                    repository.updateTranscription(id, text)
+                                }
+                                navController.navigate(Screen.MeetingMinutes.createRoute(id.toString()))
+                            }
                         }
+                    )
+                }
+
+                composable(
+                    route = Screen.MeetingMinutes.route,
+                    arguments = listOf(navArgument("uuid") { type = NavType.StringType })
+                ) { backStackEntry ->
+                    val uuidString = backStackEntry.arguments?.getString("uuid") ?: return@composable
+                    val uuid = runCatching { UUID.fromString(uuidString) }.getOrNull() ?: return@composable
+                    val database = remember { AppDatabase.getInstance(context) }
+                    val repository = remember { RecordingRepositoryImpl(database) }
+
+                    MeetingMinutesScreen(
+                        recordingUuid = uuid,
+                        repository = repository,
+                        onNavigateBack = { navController.popBackStack() },
+                        onNavigateToPaywall = { navController.navigate(Screen.Paywall.route) }
                     )
                 }
 
@@ -461,6 +489,9 @@ sealed class Screen(val route: String, val title: String) {
     object Transcription : Screen("transcription/{filePath}/{uuid}", "Transcription") {
         fun createRoute(filePath: String, uuid: String) =
             "transcription/${java.net.URLEncoder.encode(filePath, "UTF-8")}/$uuid"
+    }
+    object MeetingMinutes : Screen("meeting_minutes/{uuid}", "Meeting Minutes") {
+        fun createRoute(uuid: String) = "meeting_minutes/$uuid"
     }
     object Paywall : Screen("paywall", "Premium")
 }

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/RecordingData.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/RecordingData.kt
@@ -13,5 +13,6 @@ data class RecordingData(
     val channels: Int,
     val duration: Long,
     val filePath: String,
-    val transcriptionText: String? = null
+    val transcriptionText: String? = null,
+    val meetingMinutesText: String? = null
 )

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/db/RecordingDao.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/db/RecordingDao.kt
@@ -16,7 +16,8 @@ data class RecordingEntity(
     @ColumnInfo(name = "channels") val channels: Int,
     @ColumnInfo(name = "duration") val duration: Long,
     @ColumnInfo(name = "file_path") val filePath: String,
-    @ColumnInfo(name = "transcription_text") val transcriptionText: String? = null
+    @ColumnInfo(name = "transcription_text") val transcriptionText: String? = null,
+    @ColumnInfo(name = "meeting_minutes_text") val meetingMinutesText: String? = null
 )
 
 @Dao
@@ -35,6 +36,8 @@ interface RecordingDao {
     suspend fun updateTitle(uuid: UUID, newTitle: String)
     @Query("UPDATE recordings SET transcription_text = :text WHERE uuid = :uuid")
     suspend fun updateTranscription(uuid: UUID, text: String)
+    @Query("UPDATE recordings SET meeting_minutes_text = :text WHERE uuid = :uuid")
+    suspend fun updateMeetingMinutes(uuid: UUID, text: String)
 }
 
 val MIGRATION_2_3 = object : androidx.room.migration.Migration(2, 3) {
@@ -43,9 +46,15 @@ val MIGRATION_2_3 = object : androidx.room.migration.Migration(2, 3) {
     }
 }
 
+val MIGRATION_3_4 = object : androidx.room.migration.Migration(3, 4) {
+    override fun migrate(database: androidx.sqlite.db.SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE recordings ADD COLUMN meeting_minutes_text TEXT")
+    }
+}
+
 @Database(
     entities = [RecordingEntity::class, PlaylistEntity::class, PlaylistRecordingCrossRef::class],
-    version = 3
+    version = 4
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun recordingDao(): RecordingDao
@@ -62,7 +71,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "app_database"
                 )
-                    .addMigrations(MIGRATION_2_3)
+                    .addMigrations(MIGRATION_2_3, MIGRATION_3_4)
                     .fallbackToDestructiveMigration()
                     .build()
                 INSTANCE = instance

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/record/RecordingRepository.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/record/RecordingRepository.kt
@@ -18,6 +18,8 @@ interface RecordingRepository {
     suspend fun deleteRecording(uuid: UUID)
     suspend fun updateRecordingTitle(uuid: UUID, newTitle: String)
     suspend fun updateTranscription(uuid: UUID, text: String)
+    suspend fun getRecording(uuid: UUID): RecordingData?
+    suspend fun updateMeetingMinutes(uuid: UUID, text: String)
 }
 class RecordingRepositoryImpl(private val database: AppDatabase) : RecordingRepository {
     companion object {
@@ -74,6 +76,18 @@ class RecordingRepositoryImpl(private val database: AppDatabase) : RecordingRepo
         }
     }
 
+    override suspend fun getRecording(uuid: UUID): RecordingData? {
+        return withContext(Dispatchers.IO) {
+            database.recordingDao().getRecordingById(uuid)?.toRecordingData()
+        }
+    }
+
+    override suspend fun updateMeetingMinutes(uuid: UUID, text: String) {
+        withContext(Dispatchers.IO) {
+            database.recordingDao().updateMeetingMinutes(uuid, text)
+        }
+    }
+
     private fun RecordingEntity.toRecordingData(): RecordingData {
         return RecordingData(
             uuid = this.uuid,
@@ -85,7 +99,8 @@ class RecordingRepositoryImpl(private val database: AppDatabase) : RecordingRepo
             channels = this.channels,
             duration = this.duration,
             filePath = this.filePath,
-            transcriptionText = this.transcriptionText
+            transcriptionText = this.transcriptionText,
+            meetingMinutesText = this.meetingMinutesText
         )
     }
 }

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/transcription/MeetingMinutesScreen.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/transcription/MeetingMinutesScreen.kt
@@ -1,0 +1,319 @@
+package com.entaku.simpleRecord.transcription
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.entaku.simpleRecord.R
+import com.entaku.simpleRecord.record.RecordingRepository
+import com.entaku.simpleRecord.store.PremiumRepository
+import java.util.UUID
+
+@Composable
+fun MeetingMinutesScreen(
+    recordingUuid: UUID,
+    repository: RecordingRepository,
+    onNavigateBack: () -> Unit,
+    onNavigateToPaywall: () -> Unit
+) {
+    val context = LocalContext.current
+    val premiumRepository = remember { PremiumRepository.getInstance(context) }
+    val isPremium by premiumRepository.isPremium.collectAsState()
+
+    val factory = remember(recordingUuid) { MeetingMinutesViewModelFactory(recordingUuid, repository) }
+    val viewModel: MeetingMinutesViewModel = viewModel(factory = factory)
+    val uiState by viewModel.uiState.collectAsState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 4.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onNavigateBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+            }
+            Text(
+                text = stringResource(R.string.minutes_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+        }
+
+        if (!isPremium) {
+            PremiumGateContent(onNavigateToPaywall = onNavigateToPaywall)
+        } else {
+            when (val state = uiState) {
+                is MeetingMinutesUiState.Loading -> CenteredProgress()
+                is MeetingMinutesUiState.Idle -> IdleContent(
+                    state = state,
+                    onGenerate = viewModel::generate
+                )
+                is MeetingMinutesUiState.Generating -> GeneratingContent()
+                is MeetingMinutesUiState.Done -> DoneContent(
+                    result = state.result,
+                    onSave = { viewModel.save(onSaved = onNavigateBack) },
+                    onRegenerate = viewModel::generate
+                )
+                is MeetingMinutesUiState.Failed -> FailedContent(
+                    message = state.message,
+                    onRetry = viewModel::generate
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PremiumGateContent(onNavigateToPaywall: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.padding(horizontal = 32.dp)
+        ) {
+            Icon(
+                Icons.Default.Lock,
+                contentDescription = null,
+                modifier = Modifier.size(52.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Text(
+                stringResource(R.string.minutes_premium_required),
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                textAlign = TextAlign.Center
+            )
+            Text(
+                stringResource(R.string.minutes_premium_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+            Button(onClick = onNavigateToPaywall, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.go_premium))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CenteredProgress() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun IdleContent(
+    state: MeetingMinutesUiState.Idle,
+    onGenerate: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(32.dp))
+        Icon(
+            Icons.Default.Description,
+            contentDescription = null,
+            modifier = Modifier.size(52.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            stringResource(R.string.minutes_idle_desc),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(24.dp))
+
+        if (!state.hasTranscription) {
+            Text(
+                stringResource(R.string.minutes_no_text),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.Center
+            )
+        } else {
+            Button(onClick = onGenerate, modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    stringResource(
+                        if (state.savedMinutes != null) R.string.minutes_regenerate else R.string.minutes_generate
+                    )
+                )
+            }
+        }
+
+        state.savedMinutes?.let { saved ->
+            Spacer(Modifier.height(24.dp))
+            Text(
+                stringResource(R.string.minutes_saved_title),
+                style = MaterialTheme.typography.labelMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                ),
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            MinutesResultBody(result = saved)
+        }
+        Spacer(Modifier.height(32.dp))
+    }
+}
+
+@Composable
+private fun GeneratingContent() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            CircularProgressIndicator()
+            Text(
+                stringResource(R.string.minutes_generating),
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
+            )
+            Text(
+                stringResource(R.string.transcription_processing_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun DoneContent(
+    result: MinutesResult,
+    onSave: () -> Unit,
+    onRegenerate: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp)
+    ) {
+        Spacer(Modifier.height(8.dp))
+        MinutesResultBody(result = result)
+        Spacer(Modifier.height(24.dp))
+        Button(onClick = onSave, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(R.string.save))
+        }
+        Spacer(Modifier.height(8.dp))
+        OutlinedButton(onClick = onRegenerate, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(R.string.minutes_regenerate))
+        }
+        Spacer(Modifier.height(32.dp))
+    }
+}
+
+@Composable
+private fun MinutesResultBody(result: MinutesResult) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                stringResource(R.string.minutes_summary),
+                style = MaterialTheme.typography.labelMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(result.summary, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+    if (result.todos.isNotEmpty()) {
+        Spacer(Modifier.height(12.dp))
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    stringResource(R.string.minutes_todo),
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                )
+                Spacer(Modifier.height(4.dp))
+                result.todos.forEach { todo ->
+                    Row(modifier = Modifier.padding(vertical = 4.dp)) {
+                        Icon(
+                            Icons.Default.Check,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(todo, style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FailedContent(message: String, onRetry: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.padding(32.dp)
+        ) {
+            Text(
+                stringResource(R.string.minutes_failed),
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
+            Text(
+                message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Button(onClick = onRetry) { Text(stringResource(R.string.transcription_retry)) }
+        }
+    }
+}

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/transcription/MeetingMinutesViewModel.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/transcription/MeetingMinutesViewModel.kt
@@ -1,0 +1,159 @@
+package com.entaku.simpleRecord.transcription
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.entaku.simpleRecord.record.RecordingRepository
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import java.util.UUID
+
+/**
+ * 議事録テキストの保存フォーマット（iOS の MeetingMinutesFeature と同一形式）。
+ *
+ * ```
+ * # 要約
+ * <summary>
+ *
+ * # TODO
+ * - <todo1>
+ * ```
+ */
+object MeetingMinutesFormatter {
+
+    private const val SUMMARY_HEADER = "# 要約"
+    private const val TODO_HEADER = "# TODO"
+
+    fun format(result: MinutesResult): String = buildString {
+        append(SUMMARY_HEADER)
+        append('\n')
+        append(result.summary)
+        if (result.todos.isNotEmpty()) {
+            append("\n\n")
+            append(TODO_HEADER)
+            result.todos.forEach { todo ->
+                append("\n- ")
+                append(todo)
+            }
+        }
+    }
+
+    fun parse(text: String): MinutesResult? {
+        if (!text.startsWith(SUMMARY_HEADER)) return null
+        val todoIndex = text.indexOf(TODO_HEADER)
+        val summary = if (todoIndex >= 0) {
+            text.substring(SUMMARY_HEADER.length, todoIndex)
+        } else {
+            text.substring(SUMMARY_HEADER.length)
+        }.trim()
+        val todos = if (todoIndex >= 0) {
+            text.substring(todoIndex + TODO_HEADER.length)
+                .lines()
+                .map { it.trim() }
+                .filter { it.startsWith("- ") }
+                .map { it.removePrefix("- ").trim() }
+        } else {
+            emptyList()
+        }
+        if (summary.isEmpty()) return null
+        return MinutesResult(summary = summary, todos = todos)
+    }
+}
+
+sealed class MeetingMinutesUiState {
+    object Loading : MeetingMinutesUiState()
+    data class Idle(
+        val savedMinutes: MinutesResult?,
+        val hasTranscription: Boolean
+    ) : MeetingMinutesUiState()
+    object Generating : MeetingMinutesUiState()
+    data class Done(val result: MinutesResult) : MeetingMinutesUiState()
+    data class Failed(val message: String) : MeetingMinutesUiState()
+}
+
+class MeetingMinutesViewModel(
+    private val recordingUuid: UUID,
+    private val repository: RecordingRepository,
+    private val client: TranscriptionApiClient = TranscriptionApiClient(),
+    private val tokenProvider: suspend () -> String = ::firebaseIdToken
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<MeetingMinutesUiState>(MeetingMinutesUiState.Loading)
+    val uiState: StateFlow<MeetingMinutesUiState> = _uiState.asStateFlow()
+
+    private var transcriptionText: String? = null
+
+    init {
+        viewModelScope.launch {
+            val recording = repository.getRecording(recordingUuid)
+            transcriptionText = recording?.transcriptionText?.takeIf { it.isNotBlank() }
+            val saved = recording?.meetingMinutesText?.let { MeetingMinutesFormatter.parse(it) }
+            _uiState.value = MeetingMinutesUiState.Idle(
+                savedMinutes = saved,
+                hasTranscription = transcriptionText != null
+            )
+        }
+    }
+
+    fun generate() {
+        val text = transcriptionText ?: return
+        viewModelScope.launch {
+            _uiState.value = MeetingMinutesUiState.Generating
+            try {
+                val idToken = tokenProvider()
+                val result = client.generateMinutes(idToken, text, detectSystemLanguage())
+                _uiState.value = MeetingMinutesUiState.Done(result)
+            } catch (e: Exception) {
+                _uiState.value = MeetingMinutesUiState.Failed(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    fun save(onSaved: () -> Unit) {
+        val done = _uiState.value as? MeetingMinutesUiState.Done ?: return
+        viewModelScope.launch {
+            repository.updateMeetingMinutes(recordingUuid, MeetingMinutesFormatter.format(done.result))
+            _uiState.value = MeetingMinutesUiState.Idle(
+                savedMinutes = done.result,
+                hasTranscription = transcriptionText != null
+            )
+            onSaved()
+        }
+    }
+
+    private fun detectSystemLanguage(): String {
+        val lang = java.util.Locale.getDefault().language
+        return when {
+            lang.startsWith("ja") -> "ja"
+            lang.startsWith("zh") -> "zh"
+            lang.startsWith("ko") -> "ko"
+            lang.startsWith("de") -> "de"
+            lang.startsWith("fr") -> "fr"
+            lang.startsWith("es") -> "es"
+            else -> "en"
+        }
+    }
+}
+
+private suspend fun firebaseIdToken(): String {
+    val auth = FirebaseAuth.getInstance()
+    if (auth.currentUser == null) {
+        auth.signInAnonymously().await()
+    }
+    return auth.currentUser!!.getIdToken(false).await().token
+        ?: error("Failed to get Firebase ID token")
+}
+
+class MeetingMinutesViewModelFactory(
+    private val recordingUuid: UUID,
+    private val repository: RecordingRepository
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        @Suppress("UNCHECKED_CAST")
+        return MeetingMinutesViewModel(recordingUuid, repository) as T
+    }
+}

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/transcription/TranscriptionApiClient.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/transcription/TranscriptionApiClient.kt
@@ -20,6 +20,11 @@ data class TranscriptionResult(
     val summary: String
 )
 
+data class MinutesResult(
+    val summary: String,
+    val todos: List<String>
+)
+
 class TranscriptionApiClient {
 
     private val baseUrl = BuildConfig.TRANSCRIPTION_SERVER_URL
@@ -97,6 +102,46 @@ class TranscriptionApiClient {
                 transcription = json.optString("transcription", ""),
                 segments = segments,
                 summary = json.optString("summary", "")
+            )
+        }
+
+    suspend fun generateMinutes(idToken: String, text: String, language: String): MinutesResult =
+        withContext(Dispatchers.IO) {
+            val url = URL("$baseUrl/minutes")
+            val conn = (url.openConnection() as HttpURLConnection).apply {
+                requestMethod = "POST"
+                setRequestProperty("Authorization", "Bearer $idToken")
+                setRequestProperty("Content-Type", "application/json")
+                connectTimeout = 30_000
+                readTimeout = 180_000
+                doOutput = true
+            }
+            // text には改行や引用符が含まれるため JSONObject でエスケープして組み立てる
+            val body = JSONObject()
+                .put("text", text)
+                .put("language", language)
+                .toString()
+                .toByteArray()
+            conn.outputStream.use { it.write(body) }
+
+            val status = conn.responseCode
+            val responseBody = if (status in 200..299) {
+                conn.inputStream.bufferedReader().readText()
+            } else {
+                conn.errorStream?.bufferedReader()?.readText() ?: ""
+            }
+            if (status !in 200..299) error("minutes failed: $status $responseBody")
+
+            val json = JSONObject(responseBody)
+            val todos = mutableListOf<String>()
+            json.optJSONArray("todos")?.let { arr ->
+                for (i in 0 until arr.length()) {
+                    todos.add(arr.getString(i))
+                }
+            }
+            MinutesResult(
+                summary = json.optString("summary", ""),
+                todos = todos
             )
         }
 }

--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/transcription/TranscriptionScreen.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/transcription/TranscriptionScreen.kt
@@ -66,7 +66,8 @@ fun TranscriptionScreen(
     audioFilePath: String,
     recordingUuid: UUID?,
     onNavigateBack: () -> Unit,
-    onTranscriptionSaved: ((UUID, String) -> Unit)? = null
+    onTranscriptionSaved: ((UUID, String) -> Unit)? = null,
+    onNavigateToMeetingMinutes: ((UUID, String) -> Unit)? = null
 ) {
     val factory = remember(audioFilePath) { TranscriptionViewModelFactory(audioFilePath) }
     val viewModel: TranscriptionViewModel = viewModel(factory = factory)
@@ -105,6 +106,13 @@ fun TranscriptionScreen(
                     context.startActivity(android.content.Intent.createChooser(sendIntent, null))
                 }) {
                     Icon(Icons.Default.Share, contentDescription = null)
+                }
+                if (recordingUuid != null && onNavigateToMeetingMinutes != null) {
+                    TextButton(onClick = {
+                        onNavigateToMeetingMinutes(recordingUuid, result.transcription)
+                    }) {
+                        Text(stringResource(R.string.minutes_title))
+                    }
                 }
                 TextButton(onClick = {
                     recordingUuid?.let { onTranscriptionSaved?.invoke(it, result.transcription) }

--- a/android/simpleRecord/app/src/main/res/values-de/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-de/strings.xml
@@ -167,6 +167,20 @@
     <string name="transcription_retry">Wiederholen</string>
     <string name="transcription_summary">Zusammenfassung</string>
 
+    <!-- Meeting Minutes -->
+    <string name="minutes_title">Protokoll</string>
+    <string name="minutes_premium_required">KI-Sitzungsprotokoll ist eine Premium-Funktion</string>
+    <string name="minutes_premium_desc">Abonnieren Sie, um automatisch Zusammenfassungen und TODOs aus Transkriptionsergebnissen zu erstellen.</string>
+    <string name="minutes_idle_desc">Sitzungsprotokoll automatisch aus Transkriptionsergebnissen erstellen</string>
+    <string name="minutes_no_text">Keine Transkriptionsdaten verfügbar</string>
+    <string name="minutes_generate">Protokoll erstellen</string>
+    <string name="minutes_regenerate">Neu erstellen</string>
+    <string name="minutes_generating">KI erstellt das Protokoll...</string>
+    <string name="minutes_saved_title">Vorheriges Protokoll</string>
+    <string name="minutes_summary">Zusammenfassung</string>
+    <string name="minutes_todo">TODO</string>
+    <string name="minutes_failed">Protokoll konnte nicht erstellt werden</string>
+
     <!-- Feedback Screen -->
     <string name="feedback">Feedback</string>
     <string name="feedback_category">Kategorie</string>

--- a/android/simpleRecord/app/src/main/res/values-es/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-es/strings.xml
@@ -167,6 +167,20 @@
     <string name="transcription_retry">Reintentar</string>
     <string name="transcription_summary">Resumen</string>
 
+    <!-- Meeting Minutes -->
+    <string name="minutes_title">Acta</string>
+    <string name="minutes_premium_required">Las actas de reunión con IA es una función premium</string>
+    <string name="minutes_premium_desc">Suscríbete para generar automáticamente resúmenes y TODOs a partir de los resultados de la transcripción.</string>
+    <string name="minutes_idle_desc">Generar automáticamente actas de reunión a partir de los resultados de la transcripción</string>
+    <string name="minutes_no_text">No hay datos de transcripción disponibles</string>
+    <string name="minutes_generate">Generar actas</string>
+    <string name="minutes_regenerate">Volver a generar</string>
+    <string name="minutes_generating">Generando el acta con IA...</string>
+    <string name="minutes_saved_title">Actas anteriores</string>
+    <string name="minutes_summary">Resumen</string>
+    <string name="minutes_todo">TODO</string>
+    <string name="minutes_failed">Error al generar las actas</string>
+
     <!-- Feedback Screen -->
     <string name="feedback">Comentarios</string>
     <string name="feedback_category">Categoría</string>

--- a/android/simpleRecord/app/src/main/res/values-fr/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-fr/strings.xml
@@ -167,6 +167,20 @@
     <string name="transcription_retry">Réessayer</string>
     <string name="transcription_summary">Résumé</string>
 
+    <!-- Meeting Minutes -->
+    <string name="minutes_title">Compte rendu</string>
+    <string name="minutes_premium_required">Les procès-verbaux IA est une fonctionnalité premium</string>
+    <string name="minutes_premium_desc">Abonnez-vous pour générer automatiquement des résumés et des TODOs à partir de vos résultats de transcription.</string>
+    <string name="minutes_idle_desc">Générer automatiquement des comptes rendus à partir des résultats de transcription</string>
+    <string name="minutes_no_text">Aucune donnée de transcription disponible</string>
+    <string name="minutes_generate">Générer le compte rendu</string>
+    <string name="minutes_regenerate">Régénérer</string>
+    <string name="minutes_generating">Génération du compte rendu par IA...</string>
+    <string name="minutes_saved_title">Compte rendu précédent</string>
+    <string name="minutes_summary">Résumé</string>
+    <string name="minutes_todo">TODO</string>
+    <string name="minutes_failed">Échec de la génération du compte rendu</string>
+
     <!-- Feedback Screen -->
     <string name="feedback">Commentaires</string>
     <string name="feedback_category">Catégorie</string>

--- a/android/simpleRecord/app/src/main/res/values-it/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-it/strings.xml
@@ -167,6 +167,20 @@
     <string name="transcription_retry">Riprova</string>
     <string name="transcription_summary">Riepilogo</string>
 
+    <!-- Meeting Minutes -->
+    <string name="minutes_title">Verbale</string>
+    <string name="minutes_premium_required">I verbali IA è una funzione premium</string>
+    <string name="minutes_premium_desc">Abbonati per generare automaticamente riepiloghi e TODO dai risultati della trascrizione.</string>
+    <string name="minutes_idle_desc">Genera automaticamente verbali dalle trascrizioni</string>
+    <string name="minutes_no_text">Nessun dato di trascrizione disponibile</string>
+    <string name="minutes_generate">Genera verbale</string>
+    <string name="minutes_regenerate">Rigenera</string>
+    <string name="minutes_generating">Generazione del verbale con IA...</string>
+    <string name="minutes_saved_title">Verbale precedente</string>
+    <string name="minutes_summary">Sommario</string>
+    <string name="minutes_todo">TODO</string>
+    <string name="minutes_failed">Generazione verbale fallita</string>
+
     <!-- Feedback Screen -->
     <string name="feedback">Feedback</string>
     <string name="feedback_category">Categoria</string>

--- a/android/simpleRecord/app/src/main/res/values-ja/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-ja/strings.xml
@@ -157,6 +157,20 @@
     <string name="transcription_retry">再試行</string>
     <string name="transcription_summary">要約</string>
 
+    <!-- Meeting Minutes -->
+    <string name="minutes_title">議事録</string>
+    <string name="minutes_premium_required">AI議事録はプレミアム機能です</string>
+    <string name="minutes_premium_desc">サブスクリプションに登録すると、文字起こし結果から要約とTODOを自動生成できます。</string>
+    <string name="minutes_idle_desc">文字起こし結果から議事録を自動生成します</string>
+    <string name="minutes_no_text">文字起こしデータがありません</string>
+    <string name="minutes_generate">議事録を生成</string>
+    <string name="minutes_regenerate">再生成</string>
+    <string name="minutes_generating">AIが議事録を生成中...</string>
+    <string name="minutes_saved_title">前回の議事録</string>
+    <string name="minutes_summary">要約</string>
+    <string name="minutes_todo">TODO</string>
+    <string name="minutes_failed">議事録の生成に失敗しました</string>
+
     <!-- Ads -->
     <string name="rewarded_ad_watch">広告を見る</string>
     <string name="rewarded_ad_reward_earned">ご視聴ありがとうございます！</string>

--- a/android/simpleRecord/app/src/main/res/values-pt/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-pt/strings.xml
@@ -167,6 +167,20 @@
     <string name="transcription_retry">Tentar novamente</string>
     <string name="transcription_summary">Resumo</string>
 
+    <!-- Meeting Minutes -->
+    <string name="minutes_title">Ata</string>
+    <string name="minutes_premium_required">As Atas de Reunião com IA é uma funcionalidade premium</string>
+    <string name="minutes_premium_desc">Subscreva para gerar automaticamente resumos e TODOs a partir dos resultados da transcrição.</string>
+    <string name="minutes_idle_desc">Gerar automaticamente atas de reunião a partir dos resultados da transcrição</string>
+    <string name="minutes_no_text">Não há dados de transcrição disponíveis</string>
+    <string name="minutes_generate">Gerar atas</string>
+    <string name="minutes_regenerate">Regenerar</string>
+    <string name="minutes_generating">A gerar a ata com IA...</string>
+    <string name="minutes_saved_title">Atas anteriores</string>
+    <string name="minutes_summary">Resumo</string>
+    <string name="minutes_todo">TODO</string>
+    <string name="minutes_failed">Falha ao gerar as atas</string>
+
     <!-- Feedback Screen -->
     <string name="feedback">Feedback</string>
     <string name="feedback_category">Categoria</string>

--- a/android/simpleRecord/app/src/main/res/values-ru/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-ru/strings.xml
@@ -167,6 +167,20 @@
     <string name="transcription_retry">Повторить</string>
     <string name="transcription_summary">Резюме</string>
 
+    <!-- Meeting Minutes -->
+    <string name="minutes_title">Протокол</string>
+    <string name="minutes_premium_required">Протокол совещания ИИ — премиум-функция</string>
+    <string name="minutes_premium_desc">Подпишитесь, чтобы автоматически создавать резюме и задачи из результатов транскрипции.</string>
+    <string name="minutes_idle_desc">Автоматически создавать протоколы совещаний из результатов транскрипции</string>
+    <string name="minutes_no_text">Нет данных транскрипции</string>
+    <string name="minutes_generate">Создать протокол</string>
+    <string name="minutes_regenerate">Пересоздать</string>
+    <string name="minutes_generating">ИИ создаёт протокол...</string>
+    <string name="minutes_saved_title">Предыдущий протокол</string>
+    <string name="minutes_summary">Резюме</string>
+    <string name="minutes_todo">TODO</string>
+    <string name="minutes_failed">Не удалось создать протокол</string>
+
     <!-- Feedback Screen -->
     <string name="feedback">Обратная связь</string>
     <string name="feedback_category">Категория</string>

--- a/android/simpleRecord/app/src/main/res/values-tr/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-tr/strings.xml
@@ -167,6 +167,20 @@
     <string name="transcription_retry">Tekrar Dene</string>
     <string name="transcription_summary">Özet</string>
 
+    <!-- Meeting Minutes -->
+    <string name="minutes_title">Toplantı tutanağı</string>
+    <string name="minutes_premium_required">AI Toplantı Tutanakları premium bir özelliktir</string>
+    <string name="minutes_premium_desc">Transkripsiyon sonuçlarından otomatik olarak özet ve TODO oluşturmak için abone olun.</string>
+    <string name="minutes_idle_desc">Transkripsiyon sonuçlarından toplantı tutanakları otomatik oluşturun</string>
+    <string name="minutes_no_text">Transkripsiyon verisi mevcut değil</string>
+    <string name="minutes_generate">Tutanak Oluştur</string>
+    <string name="minutes_regenerate">Yeniden Oluştur</string>
+    <string name="minutes_generating">Yapay zekâ tutanağı oluşturuyor...</string>
+    <string name="minutes_saved_title">Önceki Tutanaklar</string>
+    <string name="minutes_summary">Özet</string>
+    <string name="minutes_todo">TODO</string>
+    <string name="minutes_failed">Toplantı tutanakları oluşturulamadı</string>
+
     <!-- Feedback Screen -->
     <string name="feedback">Geri Bildirim</string>
     <string name="feedback_category">Kategori</string>

--- a/android/simpleRecord/app/src/main/res/values-vi/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-vi/strings.xml
@@ -167,6 +167,20 @@
     <string name="transcription_retry">Thử lại</string>
     <string name="transcription_summary">Tóm tắt</string>
 
+    <!-- Meeting Minutes -->
+    <string name="minutes_title">Biên bản</string>
+    <string name="minutes_premium_required">Biên bản họp AI là tính năng cao cấp</string>
+    <string name="minutes_premium_desc">Đăng ký để tự động tạo tóm tắt và TODO từ kết quả phiên âm.</string>
+    <string name="minutes_idle_desc">Tự động tạo biên bản họp từ kết quả phiên âm</string>
+    <string name="minutes_no_text">Không có dữ liệu phiên âm</string>
+    <string name="minutes_generate">Tạo biên bản</string>
+    <string name="minutes_regenerate">Tạo lại</string>
+    <string name="minutes_generating">AI đang tạo biên bản...</string>
+    <string name="minutes_saved_title">Biên bản trước</string>
+    <string name="minutes_summary">Tóm tắt</string>
+    <string name="minutes_todo">TODO</string>
+    <string name="minutes_failed">Tạo biên bản thất bại</string>
+
     <!-- Feedback Screen -->
     <string name="feedback">Phản hồi</string>
     <string name="feedback_category">Danh mục</string>

--- a/android/simpleRecord/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-zh-rCN/strings.xml
@@ -167,6 +167,20 @@
     <string name="transcription_retry">重试</string>
     <string name="transcription_summary">摘要</string>
 
+    <!-- Meeting Minutes -->
+    <string name="minutes_title">会议纪要</string>
+    <string name="minutes_premium_required">AI会议记录是高级功能</string>
+    <string name="minutes_premium_desc">订阅后，可从转录结果自动生成摘要和TODO。</string>
+    <string name="minutes_idle_desc">从转录结果自动生成会议记录</string>
+    <string name="minutes_no_text">没有转录数据</string>
+    <string name="minutes_generate">生成会议记录</string>
+    <string name="minutes_regenerate">重新生成</string>
+    <string name="minutes_generating">AI 正在生成会议纪要...</string>
+    <string name="minutes_saved_title">上次会议记录</string>
+    <string name="minutes_summary">摘要</string>
+    <string name="minutes_todo">TODO</string>
+    <string name="minutes_failed">生成会议记录失败</string>
+
     <!-- Feedback Screen -->
     <string name="feedback">反馈</string>
     <string name="feedback_category">类别</string>

--- a/android/simpleRecord/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values-zh-rTW/strings.xml
@@ -167,6 +167,20 @@
     <string name="transcription_retry">重試</string>
     <string name="transcription_summary">摘要</string>
 
+    <!-- Meeting Minutes -->
+    <string name="minutes_title">會議紀要</string>
+    <string name="minutes_premium_required">AI會議記錄是付費功能</string>
+    <string name="minutes_premium_desc">訂閱後，可從轉錄結果自動生成摘要和TODO。</string>
+    <string name="minutes_idle_desc">從轉錄結果自動生成會議記錄</string>
+    <string name="minutes_no_text">沒有轉錄資料</string>
+    <string name="minutes_generate">生成會議記錄</string>
+    <string name="minutes_regenerate">重新生成</string>
+    <string name="minutes_generating">AI 正在生成會議紀要...</string>
+    <string name="minutes_saved_title">上次會議記錄</string>
+    <string name="minutes_summary">摘要</string>
+    <string name="minutes_todo">TODO</string>
+    <string name="minutes_failed">生成會議記錄失敗</string>
+
     <!-- Feedback Screen -->
     <string name="feedback">意見回饋</string>
     <string name="feedback_category">類別</string>

--- a/android/simpleRecord/app/src/main/res/values/strings.xml
+++ b/android/simpleRecord/app/src/main/res/values/strings.xml
@@ -179,6 +179,20 @@
     <string name="transcription_retry">Retry</string>
     <string name="transcription_summary">Summary</string>
 
+    <!-- Meeting Minutes -->
+    <string name="minutes_title">Meeting Minutes</string>
+    <string name="minutes_premium_required">AI Meeting Minutes is a Premium Feature</string>
+    <string name="minutes_premium_desc">Subscribe to automatically generate summaries and TODOs from your transcription results.</string>
+    <string name="minutes_idle_desc">Automatically generate meeting minutes from transcription results</string>
+    <string name="minutes_no_text">No transcription data available</string>
+    <string name="minutes_generate">Generate Minutes</string>
+    <string name="minutes_regenerate">Regenerate</string>
+    <string name="minutes_generating">Generating meeting minutes with AI...</string>
+    <string name="minutes_saved_title">Previous Meeting Minutes</string>
+    <string name="minutes_summary">Summary</string>
+    <string name="minutes_todo">TODO</string>
+    <string name="minutes_failed">Failed to Generate Meeting Minutes</string>
+
     <!-- Feedback Screen -->
     <string name="feedback">Feedback</string>
     <string name="feedback_category">Category</string>

--- a/android/simpleRecord/app/src/test/java/com/entaku/simpleRecord/transcription/MeetingMinutesFormatterTest.kt
+++ b/android/simpleRecord/app/src/test/java/com/entaku/simpleRecord/transcription/MeetingMinutesFormatterTest.kt
@@ -1,0 +1,49 @@
+package com.entaku.simpleRecord.transcription
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MeetingMinutesFormatterTest {
+
+    @Test
+    fun `format with todos produces summary and todo sections`() {
+        val result = MinutesResult(summary = "会議の要約です。", todos = listOf("資料を送付", "日程調整"))
+        val text = MeetingMinutesFormatter.format(result)
+        assertEquals(
+            "# 要約\n会議の要約です。\n\n# TODO\n- 資料を送付\n- 日程調整",
+            text
+        )
+    }
+
+    @Test
+    fun `format without todos omits todo section`() {
+        val result = MinutesResult(summary = "要約のみ", todos = emptyList())
+        assertEquals("# 要約\n要約のみ", MeetingMinutesFormatter.format(result))
+    }
+
+    @Test
+    fun `parse roundtrips formatted output`() {
+        val original = MinutesResult(summary = "議論の内容", todos = listOf("TODO1", "TODO2"))
+        val parsed = MeetingMinutesFormatter.parse(MeetingMinutesFormatter.format(original))
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun `parse roundtrips summary-only output`() {
+        val original = MinutesResult(summary = "要約だけ", todos = emptyList())
+        val parsed = MeetingMinutesFormatter.parse(MeetingMinutesFormatter.format(original))
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun `parse returns null for non-minutes text`() {
+        assertNull(MeetingMinutesFormatter.parse("ただのメモ"))
+        assertNull(MeetingMinutesFormatter.parse(""))
+    }
+
+    @Test
+    fun `parse returns null when summary is empty`() {
+        assertNull(MeetingMinutesFormatter.parse("# 要約\n\n\n# TODO\n- x"))
+    }
+}

--- a/android/simpleRecord/app/src/test/java/com/entaku/simpleRecord/transcription/MeetingMinutesViewModelTest.kt
+++ b/android/simpleRecord/app/src/test/java/com/entaku/simpleRecord/transcription/MeetingMinutesViewModelTest.kt
@@ -1,0 +1,157 @@
+package com.entaku.simpleRecord.transcription
+
+import com.entaku.simpleRecord.RecordingData
+import com.entaku.simpleRecord.record.RecordingRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MeetingMinutesViewModelTest {
+
+    private val uuid: UUID = UUID.randomUUID()
+    private lateinit var repository: FakeRecordingRepository
+    private lateinit var client: TranscriptionApiClient
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        repository = FakeRecordingRepository()
+        client = mockk()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun recording(
+        transcription: String? = "会議の文字起こしテキスト",
+        minutes: String? = null
+    ) = RecordingData(
+        uuid = uuid,
+        title = "test",
+        creationDate = LocalDateTime.of(2026, 7, 5, 0, 0),
+        fileExtension = "m4a",
+        khz = "44.1",
+        bitRate = 128,
+        channels = 1,
+        duration = 60L,
+        filePath = "/tmp/test.m4a",
+        transcriptionText = transcription,
+        meetingMinutesText = minutes
+    )
+
+    private fun viewModel() = MeetingMinutesViewModel(
+        recordingUuid = uuid,
+        repository = repository,
+        client = client,
+        tokenProvider = { "fake-token" }
+    )
+
+    @Test
+    fun `init loads recording and becomes Idle with transcription`() = runTest {
+        repository.stored = recording()
+        val vm = viewModel()
+        val state = vm.uiState.value as MeetingMinutesUiState.Idle
+        assertTrue(state.hasTranscription)
+        assertEquals(null, state.savedMinutes)
+    }
+
+    @Test
+    fun `init parses saved minutes`() = runTest {
+        val saved = MeetingMinutesFormatter.format(MinutesResult("保存済み要約", listOf("既存TODO")))
+        repository.stored = recording(minutes = saved)
+        val vm = viewModel()
+        val state = vm.uiState.value as MeetingMinutesUiState.Idle
+        assertEquals(MinutesResult("保存済み要約", listOf("既存TODO")), state.savedMinutes)
+    }
+
+    @Test
+    fun `init without transcription sets hasTranscription false`() = runTest {
+        repository.stored = recording(transcription = null)
+        val vm = viewModel()
+        val state = vm.uiState.value as MeetingMinutesUiState.Idle
+        assertFalse(state.hasTranscription)
+    }
+
+    @Test
+    fun `generate success transitions to Done`() = runTest {
+        repository.stored = recording()
+        coEvery { client.generateMinutes(any(), any(), any()) } returns
+            MinutesResult("生成された要約", listOf("TODO A"))
+
+        val vm = viewModel()
+        vm.generate()
+
+        val state = vm.uiState.value as MeetingMinutesUiState.Done
+        assertEquals("生成された要約", state.result.summary)
+        assertEquals(listOf("TODO A"), state.result.todos)
+    }
+
+    @Test
+    fun `generate failure transitions to Failed`() = runTest {
+        repository.stored = recording()
+        coEvery { client.generateMinutes(any(), any(), any()) } throws RuntimeException("server error")
+
+        val vm = viewModel()
+        vm.generate()
+
+        assertTrue(vm.uiState.value is MeetingMinutesUiState.Failed)
+    }
+
+    @Test
+    fun `generate without transcription does nothing`() = runTest {
+        repository.stored = recording(transcription = null)
+        val vm = viewModel()
+        vm.generate()
+        assertTrue(vm.uiState.value is MeetingMinutesUiState.Idle)
+    }
+
+    @Test
+    fun `save persists formatted minutes and invokes callback`() = runTest {
+        repository.stored = recording()
+        coEvery { client.generateMinutes(any(), any(), any()) } returns
+            MinutesResult("要約", listOf("TODO1"))
+
+        val vm = viewModel()
+        vm.generate()
+        var savedCallback = false
+        vm.save { savedCallback = true }
+
+        assertTrue(savedCallback)
+        assertEquals("# 要約\n要約\n\n# TODO\n- TODO1", repository.savedMinutes[uuid])
+        val state = vm.uiState.value as MeetingMinutesUiState.Idle
+        assertEquals(MinutesResult("要約", listOf("TODO1")), state.savedMinutes)
+    }
+}
+
+private class FakeRecordingRepository : RecordingRepository {
+    var stored: RecordingData? = null
+    val savedMinutes = mutableMapOf<UUID, String>()
+
+    override suspend fun saveRecordingData(recordingData: RecordingData) = Unit
+    override fun getAllRecordings(): Flow<List<RecordingData>> = flowOf(emptyList())
+    override suspend fun deleteRecording(uuid: UUID) = Unit
+    override suspend fun updateRecordingTitle(uuid: UUID, newTitle: String) = Unit
+    override suspend fun updateTranscription(uuid: UUID, text: String) = Unit
+    override suspend fun getRecording(uuid: UUID): RecordingData? = stored
+    override suspend fun updateMeetingMinutes(uuid: UUID, text: String) {
+        savedMinutes[uuid] = text
+    }
+}

--- a/server/transcription/main.go
+++ b/server/transcription/main.go
@@ -34,7 +34,9 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
-func init() {
+// initClients は外部クライアントを初期化する。
+// init() ではなく main() から呼ぶことで、単体テスト時に認証情報を要求しない。
+func initClients() {
 	ctx := context.Background()
 
 	app, err := firebase.NewApp(ctx, nil)
@@ -221,6 +223,96 @@ func handleTranscribe(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(result)
 }
 
+// 議事録生成: 文字起こし済みテキストから要約とTODOを生成する
+func handleMinutes(w http.ResponseWriter, r *http.Request) {
+	_, err := verifyToken(r)
+	if err != nil {
+		http.Error(w, `{"error":"Unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
+
+	var body struct {
+		Text     string `json:"text"`
+		Language string `json:"language"`
+	}
+	json.NewDecoder(r.Body).Decode(&body)
+	body.Text = strings.TrimSpace(body.Text)
+	if body.Text == "" {
+		http.Error(w, `{"error":"Text is required"}`, http.StatusBadRequest)
+		return
+	}
+	if body.Language == "" {
+		body.Language = "ja"
+	}
+	body.Text = truncateRunes(body.Text, maxMinutesInputRunes)
+
+	geminiCtx, geminiCancel := context.WithTimeout(r.Context(), 120*time.Second)
+	defer geminiCancel()
+
+	model := geminiClient.GenerativeModel(getEnv("GEMINI_MODEL", "gemini-2.5-flash"))
+	prompt := fmt.Sprintf(`以下の会議の文字起こしから議事録を作成し、次のJSON形式のみを返してください。
+出力言語: %s
+
+{
+  "summary": "会議の要約（3〜5文で簡潔に）",
+  "todos": ["会議で決まったアクションアイテムやTODO"]
+}
+
+TODOがない場合は todos を空配列にしてください。
+
+文字起こし:
+%s`, body.Language, body.Text)
+
+	resp, err := model.GenerateContent(geminiCtx, genai.Text(prompt))
+	if err != nil {
+		log.Printf("gemini minutes error: %s", redactAPIKey(err.Error()))
+		notifySlack(fmt.Sprintf(":x: [VoiLog] Minutes generation failed (Gemini)\n```%s```", sanitizeError(err)))
+		http.Error(w, `{"error":"Minutes generation failed"}`, http.StatusInternalServerError)
+		return
+	}
+
+	text := ""
+	if len(resp.Candidates) > 0 && len(resp.Candidates[0].Content.Parts) > 0 {
+		if t, ok := resp.Candidates[0].Content.Parts[0].(genai.Text); ok {
+			text = string(t)
+		}
+	}
+
+	result := parseMinutes(text)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+const maxMinutesInputRunes = 100_000
+
+func truncateRunes(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max])
+}
+
+type minutesResult struct {
+	Summary string   `json:"summary"`
+	Todos   []string `json:"todos"`
+}
+
+// parseMinutes は Gemini の出力から {summary, todos} を取り出す。
+// JSONとしてパースできない場合は本文全体を summary として返す。
+func parseMinutes(raw string) minutesResult {
+	text := extractJSON(raw)
+	var result minutesResult
+	if err := json.Unmarshal([]byte(text), &result); err != nil {
+		log.Printf("minutes json parse error: %v", err)
+		return minutesResult{Summary: strings.TrimSpace(raw), Todos: []string{}}
+	}
+	if result.Todos == nil {
+		result.Todos = []string{}
+	}
+	return result
+}
+
 func notifySlack(msg string) {
 	webhookURL := getEnv("SLACK_WEBHOOK_URL", "")
 	if webhookURL == "" {
@@ -294,9 +386,12 @@ func extractJSON(s string) string {
 }
 
 func main() {
+	initClients()
+
 	http.HandleFunc("/health", handleHealth)
 	http.HandleFunc("/upload-url", handleUploadURL)
 	http.HandleFunc("/transcribe", handleTranscribe)
+	http.HandleFunc("/minutes", handleMinutes)
 
 	port := getEnv("PORT", "8080")
 	log.Printf("listening on :%s", port)

--- a/server/transcription/main_test.go
+++ b/server/transcription/main_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseMinutes(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want minutesResult
+	}{
+		{
+			name: "plain JSON",
+			raw:  `{"summary":"要約です","todos":["TODO1","TODO2"]}`,
+			want: minutesResult{Summary: "要約です", Todos: []string{"TODO1", "TODO2"}},
+		},
+		{
+			name: "markdown fenced JSON",
+			raw:  "```json\n{\"summary\":\"要約\",\"todos\":[]}\n```",
+			want: minutesResult{Summary: "要約", Todos: []string{}},
+		},
+		{
+			name: "JSON with surrounding prose",
+			raw:  "はい、こちらが議事録です。\n{\"summary\":\"会議の要約\",\"todos\":[\"資料送付\"]}\nご確認ください。",
+			want: minutesResult{Summary: "会議の要約", Todos: []string{"資料送付"}},
+		},
+		{
+			name: "todos omitted becomes empty slice",
+			raw:  `{"summary":"要約のみ"}`,
+			want: minutesResult{Summary: "要約のみ", Todos: []string{}},
+		},
+		{
+			name: "unparseable falls back to raw text as summary",
+			raw:  "  JSONではないただのテキスト  ",
+			want: minutesResult{Summary: "JSONではないただのテキスト", Todos: []string{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseMinutes(tt.raw)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseMinutes() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	if got := truncateRunes("あいうえお", 3); got != "あいう" {
+		t.Errorf("truncateRunes multibyte = %q, want %q", got, "あいう")
+	}
+	if got := truncateRunes("short", 100); got != "short" {
+		t.Errorf("truncateRunes short = %q, want %q", got, "short")
+	}
+}
+
+func TestExtractJSON(t *testing.T) {
+	raw := "```json\n{\"a\":1}\n```"
+	if got := extractJSON(raw); got != `{"a":1}` {
+		t.Errorf("extractJSON = %q", got)
+	}
+}


### PR DESCRIPTION
## 概要

iOS 1.11.1 の AI議事録生成（Apple Intelligence）を Android にも展開し、機能差分を解消する。
Android にはオンデバイス LLM がないため、既存の文字起こしサーバー（Cloud Run + Gemini）に `POST /minutes` を追加するサーバーサイド方式で実現。

## 変更内容

### Server (`server/transcription/`)
- **`POST /minutes`**: 文字起こし済みテキストから `{summary, todos[]}` を生成（Firebase ID トークン認証、入力10万字で切り詰め、120s タイムアウト）
- クライアント初期化を `init()` → `main()` に移動し、認証情報なしで単体テストを実行可能に
- `parseMinutes` / `truncateRunes` / `extractJSON` のテスト追加（`go build`/`vet`/`test` パス）

### Android (`android/simpleRecord/`)
- **Room v3→4**: `recordings.meeting_minutes_text` 列を追加（MIGRATION_3_4）
- **MeetingMinutesScreen**: プレミアムゲート（非課金は Paywall へ誘導）→ 生成 → 要約+TODO 表示 → 保存。保存済み議事録は「前回の議事録」として再表示・再生成可能
- **導線**: 文字起こし完了画面のトップバーに「議事録」ボタンを追加（文字起こしの保存完了を待ってから遷移）
- **保存フォーマット**: iOS と同一の `# 要約 / # TODO` Markdown（`MeetingMinutesFormatter` が往復変換）
- **文言**: 12ロケール。iOS の `MeetingMinutes.xcstrings` の既存翻訳を流用（Apple Intelligence 固有文言は汎用の「AIが議事録を生成中...」に差し替え）

## テスト

- `go test` ✅（parseMinutes 5ケース + ヘルパー）
- `./gradlew test` ✅（MeetingMinutesFormatterTest 6件 + MeetingMinutesViewModelTest 7件、全既存テスト含めパス）
- `./gradlew assembleDebug` ✅

## マージ後に必要な作業

- [ ] サーバーを Cloud Run にデプロイ（`gcloud run deploy voilog-transcription` / タグ `server-v1.2.0`）— **アプリより先にデプロイ必須**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPxd5JFrDWyrAcTg5TnjzZ