### PR TITLE
fix(server): 文字起こしJSONパース失敗時に壊れたJSONが表示される問題を修正

### DIFF
--- a/server/transcription/main.go
+++ b/server/transcription/main.go
@@ -187,40 +187,109 @@ func handleTranscribe(w http.ResponseWriter, r *http.Request) {
   "summary": "内容の要約（3文以内）"
 }`, body.Language)
 
-	resp, err := model.GenerateContent(geminiCtx,
-		genai.FileData{URI: geminiFile.URI, MIMEType: mimeType},
-		genai.Text(prompt),
-	)
+	result, err := transcribeWithRetry(func() (string, error) {
+		resp, err := model.GenerateContent(geminiCtx,
+			genai.FileData{URI: geminiFile.URI, MIMEType: mimeType},
+			genai.Text(prompt),
+		)
+		if err != nil {
+			return "", err
+		}
+		text := ""
+		if len(resp.Candidates) > 0 && len(resp.Candidates[0].Content.Parts) > 0 {
+			if t, ok := resp.Candidates[0].Content.Parts[0].(genai.Text); ok {
+				text = string(t)
+			}
+		}
+		return text, nil
+	})
 	if err != nil {
 		log.Printf("gemini error: %s", redactAPIKey(err.Error()))
 		notifySlack(fmt.Sprintf(":x: [VoiLog] Transcription failed (Gemini)\n```%s```", sanitizeError(err)))
 		http.Error(w, `{"error":"Transcription failed"}`, http.StatusInternalServerError)
 		return
 	}
-
-	// レスポンス返却
-	text := ""
-	if len(resp.Candidates) > 0 && len(resp.Candidates[0].Content.Parts) > 0 {
-		if t, ok := resp.Candidates[0].Content.Parts[0].(genai.Text); ok {
-			text = string(t)
-		}
-	}
-
-	// markdown コードブロック除去 → JSON境界抽出 → パース
-	text = extractJSON(text)
-	var result map[string]any
-	if err := json.Unmarshal([]byte(text), &result); err != nil {
-		log.Printf("json parse error: %v, raw: %s", err, text)
-		notifySlack(fmt.Sprintf(":warning: [VoiLog] JSON parse error (fell back to raw text)\n```%s```", sanitizeError(err)))
-		result = map[string]any{
-			"transcription": text,
-			"segments":      []any{},
-			"summary":       "",
-		}
+	if result == nil {
+		notifySlack(":x: [VoiLog] Transcription JSON unrecoverable after retry (no salvageable transcription field)")
+		http.Error(w, `{"error":"Transcription failed"}`, http.StatusInternalServerError)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(result)
+}
+
+// transcribeWithRetry は fetchText で Gemini の生レスポンスを取得し、JSON としてパースする。
+// パースに失敗した場合（Gemini の出力が途中で途切れるなど）は fetchText をもう一度だけ呼び直す。
+// リトライしてもパースできない場合は、壊れた JSON から transcription フィールドの値を
+// 可能な範囲でサルベージし、JSON の記号がユーザーに見えない形で返す。
+// サルベージもできない場合は nil, nil を返す（呼び出し元でエラー応答にする）。
+func transcribeWithRetry(fetchText func() (string, error)) (map[string]any, error) {
+	var lastBroken string
+	for attempt := 1; attempt <= 2; attempt++ {
+		raw, err := fetchText()
+		if err != nil {
+			return nil, err
+		}
+		text := extractJSON(raw)
+		var result map[string]any
+		if err := json.Unmarshal([]byte(text), &result); err == nil {
+			return result, nil
+		} else {
+			log.Printf("json parse error (attempt %d/2): %v, raw: %s", attempt, err, text)
+			lastBroken = text
+		}
+	}
+
+	salvaged := salvageTranscription(lastBroken)
+	if salvaged == "" {
+		return nil, nil
+	}
+	return map[string]any{
+		"transcription": salvaged,
+		"segments":      []any{},
+		"summary":       "",
+	}, nil
+}
+
+var transcriptionFieldPattern = regexp.MustCompile(`"transcription"\s*:\s*"`)
+
+// salvageTranscription は途切れた/壊れた JSON 文字列から transcription フィールドの値を
+// 可能な範囲で取り出す。JSON のエスケープシーケンス（\n, \", \\ など）を解決し、
+// クオートやブレースなどの JSON 記号がユーザーに見える形で残らないようにする。
+// フィールド自体が見つからない場合は空文字を返す。
+func salvageTranscription(broken string) string {
+	loc := transcriptionFieldPattern.FindStringIndex(broken)
+	if loc == nil {
+		return ""
+	}
+	rest := broken[loc[1]:]
+
+	var sb strings.Builder
+	for i := 0; i < len(rest); i++ {
+		c := rest[i]
+		if c == '"' {
+			break
+		}
+		if c == '\\' && i+1 < len(rest) {
+			i++
+			switch rest[i] {
+			case 'n':
+				sb.WriteByte('\n')
+			case 't':
+				sb.WriteByte('\t')
+			case '"':
+				sb.WriteByte('"')
+			case '\\':
+				sb.WriteByte('\\')
+			default:
+				sb.WriteByte(rest[i])
+			}
+			continue
+		}
+		sb.WriteByte(c)
+	}
+	return strings.TrimSpace(sb.String())
 }
 
 // 議事録生成: 文字起こし済みテキストから要約とTODOを生成する

--- a/server/transcription/main_test.go
+++ b/server/transcription/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -60,5 +62,134 @@ func TestExtractJSON(t *testing.T) {
 	raw := "```json\n{\"a\":1}\n```"
 	if got := extractJSON(raw); got != `{"a":1}` {
 		t.Errorf("extractJSON = %q", got)
+	}
+}
+
+func TestTranscribeWithRetry_SucceedsFirstTry(t *testing.T) {
+	calls := 0
+	fetch := func() (string, error) {
+		calls++
+		return `{"transcription":"こんにちは","segments":[],"summary":"挨拶"}`, nil
+	}
+	result, err := transcribeWithRetry(fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (should not retry on success)", calls)
+	}
+	if result["transcription"] != "こんにちは" {
+		t.Errorf("transcription = %v", result["transcription"])
+	}
+}
+
+func TestTranscribeWithRetry_RecoversOnRetry(t *testing.T) {
+	calls := 0
+	fetch := func() (string, error) {
+		calls++
+		if calls == 1 {
+			return `{"transcription": "途中で切れた`, nil // unexpected end of JSON input
+		}
+		return `{"transcription":"やり直し成功","segments":[],"summary":""}`, nil
+	}
+	result, err := transcribeWithRetry(fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2", calls)
+	}
+	if result["transcription"] != "やり直し成功" {
+		t.Errorf("transcription = %v, want retried result", result["transcription"])
+	}
+}
+
+func TestTranscribeWithRetry_PropagatesFetchError(t *testing.T) {
+	calls := 0
+	wantErr := errors.New("gemini api error")
+	fetch := func() (string, error) {
+		calls++
+		return "", wantErr
+	}
+	result, err := transcribeWithRetry(fetch)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if result != nil {
+		t.Errorf("result = %v, want nil", result)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (should not retry on transport error)", calls)
+	}
+}
+
+func TestTranscribeWithRetry_SalvagesAfterBothAttemptsBroken(t *testing.T) {
+	calls := 0
+	fetch := func() (string, error) {
+		calls++
+		return `{"transcription": "録音の内容はここまでしか届きませんでした`, nil
+	}
+	result, err := transcribeWithRetry(fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2", calls)
+	}
+	transcription, _ := result["transcription"].(string)
+	if transcription != "録音の内容はここまでしか届きませんでした" {
+		t.Errorf("transcription = %q, want salvaged text", transcription)
+	}
+	if strings.ContainsAny(transcription, "{}") || strings.Contains(transcription, `"transcription"`) {
+		t.Errorf("transcription leaked raw JSON syntax: %q", transcription)
+	}
+}
+
+func TestTranscribeWithRetry_UnrecoverableWhenNoTranscriptionField(t *testing.T) {
+	fetch := func() (string, error) {
+		return `{"summary": "要約だけ壊れ`, nil
+	}
+	result, err := transcribeWithRetry(fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("result = %v, want nil (unrecoverable)", result)
+	}
+}
+
+func TestSalvageTranscription(t *testing.T) {
+	tests := []struct {
+		name   string
+		broken string
+		want   string
+	}{
+		{
+			name:   "truncated mid string",
+			broken: `{"transcription": "途中で切れたテキストです`,
+			want:   "途中で切れたテキストです",
+		},
+		{
+			name:   "resolves escape sequences",
+			broken: `{"transcription": "line1\nline2\ttabbed and \"quoted\"`,
+			want:   "line1\nline2\ttabbed and \"quoted\"",
+		},
+		{
+			name:   "properly closed string",
+			broken: `{"transcription": "完全なテキスト", "summary": "壊れて`,
+			want:   "完全なテキスト",
+		},
+		{
+			name:   "field not present",
+			broken: `{"summary": "壊れて`,
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := salvageTranscription(tt.broken); got != tt.want {
+				t.Errorf("salvageTranscription() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Gemini応答のJSONパースに失敗した場合（例: `unexpected end of JSON input`）、壊れたJSON文字列がそのままユーザーの文字起こし結果として表示されていた問題を修正
- パース失敗時にGemini呼び出しを1回リトライし、それでも失敗する場合は`transcription`フィールドの値を壊れたJSONから可能な範囲でサルベージ（JSON記号を含まない形で返却）。サルベージも不可能な場合はエラーレスポンスを返す

Fixes #172

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -v`（`transcribeWithRetry` / `salvageTranscription` の新規ユニットテストを含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DETBfSvTcpBhVGMwVz8ZZ