### PR TITLE
fix(transcription): Geminiタイムアウト延長とトランジェントエラーのリトライ

### DIFF
--- a/server/transcription/main.go
+++ b/server/transcription/main.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"regexp"
@@ -17,6 +19,7 @@ import (
 	"firebase.google.com/go/v4/auth"
 	"github.com/google/generative-ai-go/genai"
 	"github.com/google/uuid"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -144,8 +147,9 @@ func handleTranscribe(w http.ResponseWriter, r *http.Request) {
 	ext := body.BlobName[strings.LastIndex(body.BlobName, ".")+1:]
 	mimeType := audioMIMEType(ext)
 
-	// Gemini操作に明示的なタイムアウトを設定（SDKデフォルトの120s上限を回避）
-	geminiCtx, geminiCancel := context.WithTimeout(r.Context(), 300*time.Second)
+	// Gemini操作に明示的なタイムアウトを設定（SDKデフォルトの120s上限を回避）。
+	// Cloud Run側のリクエストタイムアウト(600s)にバッファを残す。
+	geminiCtx, geminiCancel := context.WithTimeout(r.Context(), 480*time.Second)
 	defer geminiCancel()
 
 	// Cloud Storage から Gemini File API へストリーミングアップロード（メモリに乗せない）
@@ -188,10 +192,12 @@ func handleTranscribe(w http.ResponseWriter, r *http.Request) {
 }`, body.Language)
 
 	result, err := transcribeWithRetry(func() (string, error) {
-		resp, err := model.GenerateContent(geminiCtx,
-			genai.FileData{URI: geminiFile.URI, MIMEType: mimeType},
-			genai.Text(prompt),
-		)
+		resp, err := generateContentWithRetry(geminiCtx, generateContentAttemptTimeout, func(attemptCtx context.Context) (*genai.GenerateContentResponse, error) {
+			return model.GenerateContent(attemptCtx,
+				genai.FileData{URI: geminiFile.URI, MIMEType: mimeType},
+				genai.Text(prompt),
+			)
+		})
 		if err != nil {
 			return "", err
 		}
@@ -217,6 +223,56 @@ func handleTranscribe(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(result)
+}
+
+const generateContentAttemptTimeout = 240 * time.Second
+
+// generateContentWithRetry は callGenerate に対し、deadline exceeded やネットワーク瞬断など
+// 一時的なエラー時に限り1回だけ再試行する。JSONパース失敗のリトライ（transcribeWithRetry）とは
+// 独立したレイヤー。各試行は ctx から派生したタイムアウト付きコンテキストで実行されるため、
+// リトライしても呼び出し元が設定した ctx 全体のデッドラインを超えることはない。
+func generateContentWithRetry(ctx context.Context, timeout time.Duration, callGenerate func(context.Context) (*genai.GenerateContentResponse, error)) (*genai.GenerateContentResponse, error) {
+	var lastErr error
+	for attempt := 1; attempt <= 2; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, timeout)
+		resp, err := callGenerate(attemptCtx)
+		cancel()
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		if !isTransientGeminiError(err) {
+			return nil, err
+		}
+		if attempt == 2 || ctx.Err() != nil {
+			break
+		}
+		log.Printf("generateContent transient error (attempt %d/2), retrying: %s", attempt, redactAPIKey(err.Error()))
+	}
+	return nil, lastErr
+}
+
+// isTransientGeminiError は deadline exceeded・ネットワーク瞬断・Gemini側の5xx/429応答など
+// 再試行すれば成功しうる一時的なエラーかどうかを判定する。
+func isTransientGeminiError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		switch apiErr.Code {
+		case http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+			return true
+		}
+	}
+	return false
 }
 
 // transcribeWithRetry は fetchText で Gemini の生レスポンスを取得し、JSON としてパースする。

--- a/server/transcription/main_test.go
+++ b/server/transcription/main_test.go
@@ -1,10 +1,16 @@
 package main
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/google/generative-ai-go/genai"
+	"google.golang.org/api/googleapi"
 )
 
 func TestParseMinutes(t *testing.T) {
@@ -155,6 +161,146 @@ func TestTranscribeWithRetry_UnrecoverableWhenNoTranscriptionField(t *testing.T)
 	}
 	if result != nil {
 		t.Errorf("result = %v, want nil (unrecoverable)", result)
+	}
+}
+
+type fakeTimeoutError struct{}
+
+func (fakeTimeoutError) Error() string   { return "fake timeout" }
+func (fakeTimeoutError) Timeout() bool   { return true }
+func (fakeTimeoutError) Temporary() bool { return true }
+
+func TestIsTransientGeminiError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"wrapped deadline exceeded", fmt.Errorf("post failed: %w", context.DeadlineExceeded), true},
+		{"net timeout error", fakeTimeoutError{}, true},
+		{"googleapi 429", &googleapi.Error{Code: 429}, true},
+		{"googleapi 500", &googleapi.Error{Code: 500}, true},
+		{"googleapi 503", &googleapi.Error{Code: 503}, true},
+		{"googleapi 400 (not transient)", &googleapi.Error{Code: 400}, false},
+		{"plain error", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransientGeminiError(tt.err); got != tt.want {
+				t.Errorf("isTransientGeminiError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateContentWithRetry_SucceedsFirstTry(t *testing.T) {
+	calls := 0
+	want := &genai.GenerateContentResponse{}
+	callGenerate := func(ctx context.Context) (*genai.GenerateContentResponse, error) {
+		calls++
+		return want, nil
+	}
+	got, err := generateContentWithRetry(context.Background(), time.Second, callGenerate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (should not retry on success)", calls)
+	}
+}
+
+func TestGenerateContentWithRetry_RetriesOnceOnTransientError(t *testing.T) {
+	calls := 0
+	want := &genai.GenerateContentResponse{}
+	callGenerate := func(ctx context.Context) (*genai.GenerateContentResponse, error) {
+		calls++
+		if calls == 1 {
+			return nil, context.DeadlineExceeded
+		}
+		return want, nil
+	}
+	got, err := generateContentWithRetry(context.Background(), time.Second, callGenerate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2", calls)
+	}
+}
+
+func TestGenerateContentWithRetry_DoesNotRetryOnPermanentError(t *testing.T) {
+	calls := 0
+	wantErr := errors.New("invalid request")
+	callGenerate := func(ctx context.Context) (*genai.GenerateContentResponse, error) {
+		calls++
+		return nil, wantErr
+	}
+	_, err := generateContentWithRetry(context.Background(), time.Second, callGenerate)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (permanent errors must not be retried)", calls)
+	}
+}
+
+func TestGenerateContentWithRetry_GivesUpAfterTwoTransientErrors(t *testing.T) {
+	calls := 0
+	callGenerate := func(ctx context.Context) (*genai.GenerateContentResponse, error) {
+		calls++
+		return nil, context.DeadlineExceeded
+	}
+	_, err := generateContentWithRetry(context.Background(), time.Second, callGenerate)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context.DeadlineExceeded", err)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2 (at most one retry)", calls)
+	}
+}
+
+func TestGenerateContentWithRetry_SkipsRetryWhenParentDeadlineExpired(t *testing.T) {
+	parentCtx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+	time.Sleep(time.Millisecond)
+
+	calls := 0
+	callGenerate := func(ctx context.Context) (*genai.GenerateContentResponse, error) {
+		calls++
+		return nil, context.DeadlineExceeded
+	}
+	_, err := generateContentWithRetry(parentCtx, time.Second, callGenerate)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context.DeadlineExceeded", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (should not retry once parent ctx is already expired)", calls)
+	}
+}
+
+func TestGenerateContentWithRetry_AttemptContextBoundedByParent(t *testing.T) {
+	parentCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	var gotDeadline time.Time
+	callGenerate := func(ctx context.Context) (*genai.GenerateContentResponse, error) {
+		gotDeadline, _ = ctx.Deadline()
+		return &genai.GenerateContentResponse{}, nil
+	}
+	if _, err := generateContentWithRetry(parentCtx, time.Hour, callGenerate); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parentDeadline, _ := parentCtx.Deadline()
+	if gotDeadline.After(parentDeadline) {
+		t.Errorf("attempt deadline %v exceeds parent deadline %v", gotDeadline, parentDeadline)
 	}
 }
 


### PR DESCRIPTION
## Summary
- 本番で発生した `context deadline exceeded` による文字起こし失敗（2026-07-11、直近30日/26リクエスト中1件、オートスケール直後のコールドスタートリクエストで発生）への対処
- `handleTranscribe` の `geminiCtx` タイムアウトを 300s → 480s に延長（Cloud Run のリクエストタイムアウト 600s に対し120sのバッファを残す）
- `generateContentWithRetry` を追加し、`GenerateContent` 呼び出しが deadline exceeded・ネットワークタイムアウト・Gemini側 5xx/429 など一時的なエラーを返した場合に限り1回だけリトライする。既存のJSONパース失敗リトライ（`transcribeWithRetry`）とは独立したレイヤーで、多重リトライにはならない
- 各試行は親 `ctx` から派生したタイムアウト付きコンテキストで実行するため、リトライしても親ctxの480s上限を超えない設計

## Scope外の既知の類似課題
- `handleMinutes`（議事録生成、120sタイムアウト）にも同様にリトライが無いが、今回は本番で報告された文字起こしエラー（`handleTranscribe`）に絞って対応。必要であれば別issueで対応

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`（`generateContentWithRetry` / `isTransientGeminiError` の新規ユニットテストを含む全テストPASS）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYnMFEVak5skTDYuTSsupG