### PR TITLE
fix(transcription): /transcribe・/minutes にUIDごとのレート制限を追加

### DIFF
--- a/server/transcription/go.mod
+++ b/server/transcription/go.mod
@@ -7,6 +7,7 @@ require (
 	firebase.google.com/go/v4 v4.14.0
 	github.com/google/generative-ai-go v0.14.0
 	github.com/google/uuid v1.6.0
+	golang.org/x/time v0.5.0
 	google.golang.org/api v0.180.0
 )
 
@@ -41,7 +42,6 @@ require (
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/appengine/v2 v2.0.2 // indirect
 	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240513163218-0867130af1f8 // indirect

--- a/server/transcription/main.go
+++ b/server/transcription/main.go
@@ -11,7 +11,9 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -19,15 +21,21 @@ import (
 	"firebase.google.com/go/v4/auth"
 	"github.com/google/generative-ai-go/genai"
 	"github.com/google/uuid"
+	"golang.org/x/time/rate"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
 var (
-	firebaseAuth   *auth.Client
-	storageClient  *storage.Client
-	geminiClient   *genai.Client
-	bucketName     = getEnv("AUDIO_BUCKET", "voilog-transcription-audio")
+	firebaseAuth  *auth.Client
+	storageClient *storage.Client
+	geminiClient  *genai.Client
+	bucketName    = getEnv("AUDIO_BUCKET", "voilog-transcription-audio")
+
+	// premium会員判定を導入するまでの暫定的な濫用対策。UIDごとにGemini呼び出しを伴う
+	// エンドポイントの呼び出し回数を制限する（issue #180）。
+	transcribeLimiter = newPerUIDLimiter(parseRateEnv("TRANSCRIBE_RATE_LIMIT_PER_HOUR", 20))
+	minutesLimiter    = newPerUIDLimiter(parseRateEnv("MINUTES_RATE_LIMIT_PER_HOUR", 30))
 )
 
 func getEnv(key, fallback string) string {
@@ -76,6 +84,47 @@ func verifyToken(r *http.Request) (string, error) {
 		return "", err
 	}
 	return token.UID, nil
+}
+
+// perUIDLimiter is an in-memory per-UID token bucket. Since the service runs as a single
+// Cloud Run instance per request path (no shared store), this bounds cost abuse per instance
+// but is not a distributed guarantee across scaled-out instances.
+type perUIDLimiter struct {
+	mu       sync.Mutex
+	limiters map[string]*rate.Limiter
+	perHour  int
+}
+
+func newPerUIDLimiter(perHour int) *perUIDLimiter {
+	return &perUIDLimiter{
+		limiters: make(map[string]*rate.Limiter),
+		perHour:  perHour,
+	}
+}
+
+// Allow は指定UIDが1回分のクォータを消費できるかを返す。トークンバケット方式のため、
+// 未使用分は最大 perHour 件までバーストして消費できる（時間あたりの平均は perHour を超えない）。
+func (l *perUIDLimiter) Allow(uid string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	lim, ok := l.limiters[uid]
+	if !ok {
+		lim = rate.NewLimiter(rate.Limit(float64(l.perHour)/3600), l.perHour)
+		l.limiters[uid] = lim
+	}
+	return lim.Allow()
+}
+
+func parseRateEnv(key string, fallback int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return fallback
+	}
+	return n
 }
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -127,6 +176,10 @@ func handleTranscribe(w http.ResponseWriter, r *http.Request) {
 	uid, err := verifyToken(r)
 	if err != nil {
 		http.Error(w, `{"error":"Unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
+	if !transcribeLimiter.Allow(uid) {
+		http.Error(w, `{"error":"Rate limit exceeded"}`, http.StatusTooManyRequests)
 		return
 	}
 
@@ -350,9 +403,13 @@ func salvageTranscription(broken string) string {
 
 // 議事録生成: 文字起こし済みテキストから要約とTODOを生成する
 func handleMinutes(w http.ResponseWriter, r *http.Request) {
-	_, err := verifyToken(r)
+	uid, err := verifyToken(r)
 	if err != nil {
 		http.Error(w, `{"error":"Unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
+	if !minutesLimiter.Allow(uid) {
+		http.Error(w, `{"error":"Rate limit exceeded"}`, http.StatusTooManyRequests)
 		return
 	}
 
@@ -522,4 +579,3 @@ func main() {
 	log.Printf("listening on :%s", port)
 	log.Fatal(http.ListenAndServe(":"+port, nil))
 }
-

--- a/server/transcription/main_test.go
+++ b/server/transcription/main_test.go
@@ -13,6 +13,58 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
+func TestPerUIDLimiter_AllowsUpToBurstThenBlocks(t *testing.T) {
+	l := newPerUIDLimiter(3)
+	for i := 0; i < 3; i++ {
+		if !l.Allow("uid-a") {
+			t.Fatalf("request %d should be allowed within burst of 3", i+1)
+		}
+	}
+	if l.Allow("uid-a") {
+		t.Errorf("4th request should be blocked once burst is exhausted")
+	}
+}
+
+func TestPerUIDLimiter_TracksUsersIndependently(t *testing.T) {
+	l := newPerUIDLimiter(1)
+	if !l.Allow("uid-a") {
+		t.Fatalf("uid-a first request should be allowed")
+	}
+	if l.Allow("uid-a") {
+		t.Errorf("uid-a second request should be blocked (burst=1)")
+	}
+	if !l.Allow("uid-b") {
+		t.Errorf("uid-b should have its own independent quota")
+	}
+}
+
+func TestParseRateEnv(t *testing.T) {
+	const key = "TEST_RATE_LIMIT_PER_HOUR"
+	tests := []struct {
+		name     string
+		envValue string
+		setEnv   bool
+		fallback int
+		want     int
+	}{
+		{"unset uses fallback", "", false, 20, 20},
+		{"valid value overrides fallback", "5", true, 20, 5},
+		{"invalid value falls back", "not-a-number", true, 20, 20},
+		{"zero falls back", "0", true, 20, 20},
+		{"negative falls back", "-1", true, 20, 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(key, tt.envValue)
+			}
+			if got := parseRateEnv(key, tt.fallback); got != tt.want {
+				t.Errorf("parseRateEnv() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseMinutes(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## 概要
#180 対応。有効なFirebase認証トークンさえあれば、無料/匿名ユーザーでも `/transcribe`・`/minutes` を無制限に呼び出せ、Gemini API費用が青天井になり得た問題への暫定対策。

## 変更内容
- `perUIDLimiter`（トークンバケット、UIDごとに独立したクォータ）を追加
- `handleTranscribe` / `handleMinutes` の `verifyToken` 直後にレート制限チェックを追加。超過時は `429 Too Many Requests`
- 閾値は環境変数で調整可能（デフォルト: `TRANSCRIBE_RATE_LIMIT_PER_HOUR=20`, `MINUTES_RATE_LIMIT_PER_HOUR=30` per UID/hour）
- ユニットテスト追加（バースト制限・UIDごとの独立性・env値パース）

## スコープ外にした点（要確認）
issue本文が本命として提案していた「RevenueCat等でのプレミアム会員判定」は実装していません。調査の結果、このリポジトリにはサーバー側でRevenueCatの会員状態を検証する仕組み（webhook・Firestore同期・REST API連携）が一切存在せず、実装するには
- RevenueCat secret API keyの新規発行・Cloud Runへのシークレット設定
- entitlement識別子の決定、RevenueCat障害時のfail-open/fail-closed方針
- 無料/匿名ユーザーの扱い（レート制限のみに留めるか、機能自体を止めるか）

といったプロダクト判断とインフラ変更を伴うため、独断で実装せず別issueとして切り出すことを提案します。今回のレート制限はissue本文が「少なくとも」と挙げていた最低限の対策です。

## 検証結果（ハーネス）
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅（全テスト green、新規テスト含む）
- `gofmt -l .` ✅（差分なし）

Closes #180