### PR TITLE
fix(transcription): handleMinutesにリトライとハンドラレベル異常系テストを追加

### DIFF
--- a/server/transcription/main.go
+++ b/server/transcription/main.go
@@ -23,11 +23,17 @@ import (
 	"google.golang.org/api/option"
 )
 
+// idTokenVerifier abstracts auth.Client.VerifyIDToken so handler tests can inject a fake
+// verifier instead of requiring real Firebase credentials.
+type idTokenVerifier interface {
+	VerifyIDToken(ctx context.Context, idToken string) (*auth.Token, error)
+}
+
 var (
-	firebaseAuth   *auth.Client
-	storageClient  *storage.Client
-	geminiClient   *genai.Client
-	bucketName     = getEnv("AUDIO_BUCKET", "voilog-transcription-audio")
+	firebaseAuth  idTokenVerifier
+	storageClient *storage.Client
+	geminiClient  *genai.Client
+	bucketName    = getEnv("AUDIO_BUCKET", "voilog-transcription-audio")
 )
 
 func getEnv(key, fallback string) string {
@@ -227,6 +233,22 @@ func handleTranscribe(w http.ResponseWriter, r *http.Request) {
 
 const generateContentAttemptTimeout = 240 * time.Second
 
+// minutesAttemptTimeout は handleMinutes の geminiCtx（120s）に対して、
+// generateContentWithRetry が最大2回試行してもgeminiCtxの期限内に収まるよう半分の値にする。
+const minutesAttemptTimeout = 60 * time.Second
+
+// contentGenerator abstracts genai.GenerativeModel.GenerateContent so handleMinutes'
+// HTTPハンドラレベルの異常系テストが実際のGeminiクライアントなしで書けるようにする。
+type contentGenerator interface {
+	GenerateContent(ctx context.Context, parts ...genai.Part) (*genai.GenerateContentResponse, error)
+}
+
+// newMinutesModel は handleMinutes が使うGeminiモデルを生成する。テストでは差し替え可能にする
+// ためパッケージ変数にしている。
+var newMinutesModel = func() contentGenerator {
+	return geminiClient.GenerativeModel(getEnv("GEMINI_MODEL", "gemini-2.5-flash"))
+}
+
 // generateContentWithRetry は callGenerate に対し、deadline exceeded やネットワーク瞬断など
 // 一時的なエラー時に限り1回だけ再試行する。JSONパース失敗のリトライ（transcribeWithRetry）とは
 // 独立したレイヤー。各試行は ctx から派生したタイムアウト付きコンテキストで実行されるため、
@@ -374,7 +396,7 @@ func handleMinutes(w http.ResponseWriter, r *http.Request) {
 	geminiCtx, geminiCancel := context.WithTimeout(r.Context(), 120*time.Second)
 	defer geminiCancel()
 
-	model := geminiClient.GenerativeModel(getEnv("GEMINI_MODEL", "gemini-2.5-flash"))
+	model := newMinutesModel()
 	prompt := fmt.Sprintf(`以下の会議の文字起こしから議事録を作成し、次のJSON形式のみを返してください。
 出力言語: %s
 
@@ -388,7 +410,9 @@ TODOがない場合は todos を空配列にしてください。
 文字起こし:
 %s`, body.Language, body.Text)
 
-	resp, err := model.GenerateContent(geminiCtx, genai.Text(prompt))
+	resp, err := generateContentWithRetry(geminiCtx, minutesAttemptTimeout, func(attemptCtx context.Context) (*genai.GenerateContentResponse, error) {
+		return model.GenerateContent(attemptCtx, genai.Text(prompt))
+	})
 	if err != nil {
 		log.Printf("gemini minutes error: %s", redactAPIKey(err.Error()))
 		notifySlack(fmt.Sprintf(":x: [VoiLog] Minutes generation failed (Gemini)\n```%s```", sanitizeError(err)))
@@ -522,4 +546,3 @@ func main() {
 	log.Printf("listening on :%s", port)
 	log.Fatal(http.ListenAndServe(":"+port, nil))
 }
-

--- a/server/transcription/main_test.go
+++ b/server/transcription/main_test.go
@@ -2,16 +2,133 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	firebaseauth "firebase.google.com/go/v4/auth"
 	"github.com/google/generative-ai-go/genai"
 	"google.golang.org/api/googleapi"
 )
+
+type fakeVerifier struct {
+	uid string
+	err error
+}
+
+func (f fakeVerifier) VerifyIDToken(ctx context.Context, idToken string) (*firebaseauth.Token, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &firebaseauth.Token{UID: f.uid}, nil
+}
+
+type fakeGenerator struct {
+	text string
+	err  error
+}
+
+func (f fakeGenerator) GenerateContent(ctx context.Context, parts ...genai.Part) (*genai.GenerateContentResponse, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{Content: &genai.Content{Parts: []genai.Part{genai.Text(f.text)}}},
+		},
+	}, nil
+}
+
+// withMinutesFakes swaps firebaseAuth/newMinutesModel for the duration of the test and
+// restores the originals afterward, since both are package-level vars.
+func withMinutesFakes(t *testing.T, verifier idTokenVerifier, generator contentGenerator) {
+	t.Helper()
+	origAuth, origModel := firebaseAuth, newMinutesModel
+	firebaseAuth = verifier
+	newMinutesModel = func() contentGenerator { return generator }
+	t.Cleanup(func() {
+		firebaseAuth = origAuth
+		newMinutesModel = origModel
+	})
+}
+
+func TestHandleMinutes_Unauthorized_NoHeader(t *testing.T) {
+	withMinutesFakes(t, fakeVerifier{uid: "user-1"}, fakeGenerator{text: `{"summary":"s","todos":[]}`})
+	req := httptest.NewRequest(http.MethodPost, "/minutes", strings.NewReader(`{"text":"hello"}`))
+	w := httptest.NewRecorder()
+
+	handleMinutes(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestHandleMinutes_Unauthorized_InvalidToken(t *testing.T) {
+	withMinutesFakes(t, fakeVerifier{err: errors.New("invalid token")}, fakeGenerator{text: `{"summary":"s","todos":[]}`})
+	req := httptest.NewRequest(http.MethodPost, "/minutes", strings.NewReader(`{"text":"hello"}`))
+	req.Header.Set("Authorization", "Bearer bad-token")
+	w := httptest.NewRecorder()
+
+	handleMinutes(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestHandleMinutes_EmptyText_BadRequest(t *testing.T) {
+	withMinutesFakes(t, fakeVerifier{uid: "user-1"}, fakeGenerator{text: `{"summary":"s","todos":[]}`})
+	req := httptest.NewRequest(http.MethodPost, "/minutes", strings.NewReader(`{"text":"   "}`))
+	req.Header.Set("Authorization", "Bearer good-token")
+	w := httptest.NewRecorder()
+
+	handleMinutes(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleMinutes_GeminiFailure_InternalServerError(t *testing.T) {
+	withMinutesFakes(t, fakeVerifier{uid: "user-1"}, fakeGenerator{err: errors.New("gemini unavailable")})
+	req := httptest.NewRequest(http.MethodPost, "/minutes", strings.NewReader(`{"text":"会議の内容です"}`))
+	req.Header.Set("Authorization", "Bearer good-token")
+	w := httptest.NewRecorder()
+
+	handleMinutes(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestHandleMinutes_Success(t *testing.T) {
+	withMinutesFakes(t, fakeVerifier{uid: "user-1"}, fakeGenerator{text: `{"summary":"要約","todos":["TODO1"]}`})
+	req := httptest.NewRequest(http.MethodPost, "/minutes", strings.NewReader(`{"text":"会議の内容です"}`))
+	req.Header.Set("Authorization", "Bearer good-token")
+	w := httptest.NewRecorder()
+
+	handleMinutes(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var got minutesResult
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	want := minutesResult{Summary: "要約", Todos: []string{"TODO1"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("result = %+v, want %+v", got, want)
+	}
+}
 
 func TestParseMinutes(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## 概要
#181 対応。`/transcribe`(handleTranscribe)には`generateContentWithRetry`によるトランジェントエラー(429/500/502/503/timeout等)のリトライが既にあったが、`/minutes`(handleMinutes)は`model.GenerateContent`を1回呼ぶだけで非対称だった。

## 変更内容
- `handleMinutes`のGemini呼び出しを`generateContentWithRetry`経由に変更。`minutesAttemptTimeout`(60s)を新設し、既存の`geminiCtx`(120s)の期限内に最大2回試行できるようにした（`handleTranscribe`のattemptTimeout=overall/2という既存比率に合わせた）
- `handleMinutes`のHTTPハンドラレベルの異常系が一切テストされていなかったため、`firebaseAuth`と Gemini モデル生成をテストで差し替え可能にする最小限のインターフェース（`idTokenVerifier`, `contentGenerator`）を導入
- 追加したテスト: 認証ヘッダなし401 / 認証失敗401 / 空text時400 / Gemini呼び出し失敗時500 / 正常系200

## 検証結果（ハーネス）
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅（新規テスト5件含め全green）
- `gofmt -l .` ✅（差分なし）

Closes #181