### PR TITLE
test(android): PaywallScreen年額プラン分岐のユニットテストを追加

### DIFF
--- a/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/store/PaywallScreen.kt
+++ b/android/simpleRecord/app/src/main/java/com/entaku/simpleRecord/store/PaywallScreen.kt
@@ -257,6 +257,47 @@ private fun PlanButton(
     }
 }
 
+/**
+ * 年額プラン選択UIの分岐状態。年額パッケージの有無で表示モードが変わる（issue #182）。
+ * - [Unavailable]: 月額パッケージすら取得できない
+ * - [SinglePlan]: 年額パッケージが無く、月額単一UIにフォールバック
+ * - [DualPlan]: 月額・年額とも揃っており、プラン選択UIを表示
+ */
+internal sealed class PaywallPlansUiState {
+    data object Unavailable : PaywallPlansUiState()
+    data class SinglePlan(val product: PremiumProduct) : PaywallPlansUiState()
+    data class DualPlan(
+        val monthly: PremiumProduct,
+        val annual: PremiumProduct,
+        val isAnnualSelected: Boolean
+    ) : PaywallPlansUiState() {
+        val selectedProduct: PremiumProduct get() = if (isAnnualSelected) annual else monthly
+    }
+}
+
+/**
+ * offeringの商品リストと現在の選択状態から、Paywall画面の表示モードを決定する。
+ * 年額パッケージが取得できない場合は自動的に月額単一UI（[PaywallPlansUiState.SinglePlan]）に
+ * フォールバックする。
+ */
+internal fun resolvePaywallPlansUiState(
+    products: List<PremiumProduct>,
+    isAnnualSelected: Boolean
+): PaywallPlansUiState {
+    val monthly = products.firstOrNull { it.planType == PlanType.MONTHLY }
+        ?: products.firstOrNull()
+    val annual = products.firstOrNull { it.planType == PlanType.ANNUAL }
+    return when {
+        monthly == null -> PaywallPlansUiState.Unavailable
+        annual == null -> PaywallPlansUiState.SinglePlan(monthly)
+        else -> PaywallPlansUiState.DualPlan(monthly, annual, isAnnualSelected)
+    }
+}
+
+/** 年額パッケージがofferingに存在する場合、Paywall画面の初期選択状態は年額をデフォルトにする。 */
+internal fun defaultIsAnnualSelected(products: List<PremiumProduct>): Boolean =
+    products.any { it.planType == PlanType.ANNUAL }
+
 @Composable
 private fun BillingContent(
     billingState: BillingState,
@@ -291,75 +332,41 @@ private fun BillingContent(
             }
         }
         is BillingState.Ready -> {
-            val monthly = state.products.firstOrNull { it.planType == PlanType.MONTHLY }
-                ?: state.products.firstOrNull()
-            val annual = state.products.firstOrNull { it.planType == PlanType.ANNUAL }
-            if (monthly != null) {
-                // 年額パッケージがofferingに存在する場合のみセレクターを表示する。
-                // 存在しない場合は従来どおり単一プラン（月額）のUIにフォールバックする。
-                var isAnnualSelected by rememberSaveable(annual != null) {
-                    mutableStateOf(annual != null)
-                }
-                val selectedProduct = if (isAnnualSelected && annual != null) annual else monthly
+            // 年額パッケージがofferingに存在する場合のみセレクターを表示する。
+            // 存在しない場合は従来どおり単一プラン（月額）のUIにフォールバックする。
+            val hasAnnual = defaultIsAnnualSelected(state.products)
+            var isAnnualSelected by rememberSaveable(hasAnnual) { mutableStateOf(hasAnnual) }
 
-                if (annual != null) {
+            when (val plans = resolvePaywallPlansUiState(state.products, isAnnualSelected)) {
+                is PaywallPlansUiState.Unavailable -> {
+                    Text(
+                        stringResource(R.string.premium_unavailable),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
+                }
+                is PaywallPlansUiState.SinglePlan -> {
+                    PurchasePlanSection(
+                        product = plans.product,
+                        activity = activity,
+                        billingManager = billingManager
+                    )
+                }
+                is PaywallPlansUiState.DualPlan -> {
                     PlanSelector(
-                        monthly = monthly,
-                        annual = annual,
-                        isAnnualSelected = isAnnualSelected,
+                        monthly = plans.monthly,
+                        annual = plans.annual,
+                        isAnnualSelected = plans.isAnnualSelected,
                         onSelect = { isAnnualSelected = it }
                     )
                     Spacer(Modifier.height(16.dp))
+                    PurchasePlanSection(
+                        product = plans.selectedProduct,
+                        activity = activity,
+                        billingManager = billingManager
+                    )
                 }
-                Button(
-                    onClick = {
-                        if (activity != null) {
-                            billingManager.launchPurchaseFlow(activity, selectedProduct)
-                        } else {
-                            android.util.Log.e("BillingContent", "Activity is null — cannot launch purchase flow")
-                        }
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(
-                            stringResource(R.string.premium_free_trial),
-                            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
-                        )
-                        Text(
-                            stringResource(
-                                if (selectedProduct.planType == PlanType.ANNUAL) {
-                                    R.string.premium_trial_then_price_annual
-                                } else {
-                                    R.string.premium_trial_then_price
-                                },
-                                selectedProduct.price
-                            ),
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
-                }
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    stringResource(
-                        if (selectedProduct.planType == PlanType.ANNUAL) {
-                            R.string.premium_trial_terms_annual
-                        } else {
-                            R.string.premium_trial_terms
-                        },
-                        selectedProduct.price
-                    ),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center
-                )
-            } else {
-                Text(
-                    stringResource(R.string.premium_unavailable),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center
-                )
             }
             Spacer(Modifier.height(16.dp))
             OutlinedButton(
@@ -370,4 +377,54 @@ private fun BillingContent(
             }
         }
     }
+}
+
+@Composable
+private fun PurchasePlanSection(
+    product: PremiumProduct,
+    activity: Activity?,
+    billingManager: BillingRepository
+) {
+    Button(
+        onClick = {
+            if (activity != null) {
+                billingManager.launchPurchaseFlow(activity, product)
+            } else {
+                android.util.Log.e("BillingContent", "Activity is null — cannot launch purchase flow")
+            }
+        },
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                stringResource(R.string.premium_free_trial),
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
+            Text(
+                stringResource(
+                    if (product.planType == PlanType.ANNUAL) {
+                        R.string.premium_trial_then_price_annual
+                    } else {
+                        R.string.premium_trial_then_price
+                    },
+                    product.price
+                ),
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+    }
+    Spacer(Modifier.height(8.dp))
+    Text(
+        stringResource(
+            if (product.planType == PlanType.ANNUAL) {
+                R.string.premium_trial_terms_annual
+            } else {
+                R.string.premium_trial_terms
+            },
+            product.price
+        ),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center
+    )
 }

--- a/android/simpleRecord/app/src/test/java/com/entaku/simpleRecord/store/PaywallScreenTest.kt
+++ b/android/simpleRecord/app/src/test/java/com/entaku/simpleRecord/store/PaywallScreenTest.kt
@@ -1,0 +1,86 @@
+package com.entaku.simpleRecord.store
+
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PaywallScreenTest {
+
+    private fun product(planType: PlanType, id: String = planType.name, price: String = "¥300") =
+        PremiumProduct(id, id, price, planType, mockk())
+
+    // --- resolvePaywallPlansUiState ---
+
+    @Test
+    fun `no products resolves to Unavailable`() {
+        val result = resolvePaywallPlansUiState(emptyList(), isAnnualSelected = false)
+        assertEquals(PaywallPlansUiState.Unavailable, result)
+    }
+
+    @Test
+    fun `annual package unavailable falls back to single monthly plan UI`() {
+        val monthly = product(PlanType.MONTHLY, price = "¥300")
+        val result = resolvePaywallPlansUiState(listOf(monthly), isAnnualSelected = true)
+
+        val single = result as? PaywallPlansUiState.SinglePlan
+            ?: error("expected SinglePlan, got $result")
+        assertEquals(monthly, single.product)
+    }
+
+    @Test
+    fun `monthly and annual both available resolves to DualPlan`() {
+        val monthly = product(PlanType.MONTHLY)
+        val annual = product(PlanType.ANNUAL)
+        val result = resolvePaywallPlansUiState(listOf(monthly, annual), isAnnualSelected = true)
+
+        val dual = result as? PaywallPlansUiState.DualPlan
+            ?: error("expected DualPlan, got $result")
+        assertEquals(monthly, dual.monthly)
+        assertEquals(annual, dual.annual)
+        assertTrue(dual.isAnnualSelected)
+    }
+
+    @Test
+    fun `DualPlan selectedProduct follows isAnnualSelected flag`() {
+        val monthly = product(PlanType.MONTHLY)
+        val annual = product(PlanType.ANNUAL)
+
+        val annualSelected = resolvePaywallPlansUiState(listOf(monthly, annual), isAnnualSelected = true)
+            as PaywallPlansUiState.DualPlan
+        assertEquals(annual, annualSelected.selectedProduct)
+
+        val monthlySelected = resolvePaywallPlansUiState(listOf(monthly, annual), isAnnualSelected = false)
+            as PaywallPlansUiState.DualPlan
+        assertEquals(monthly, monthlySelected.selectedProduct)
+    }
+
+    @Test
+    fun `no MONTHLY-typed product falls back to first product as monthly slot`() {
+        // offeringにMONTHLY種別が無い場合、既存挙動を保つため先頭商品を月額枠として扱う
+        val other = product(PlanType.OTHER, id = "other")
+        val result = resolvePaywallPlansUiState(listOf(other), isAnnualSelected = false)
+
+        val single = result as? PaywallPlansUiState.SinglePlan
+            ?: error("expected SinglePlan, got $result")
+        assertEquals(other, single.product)
+    }
+
+    // --- defaultIsAnnualSelected ---
+
+    @Test
+    fun `defaultIsAnnualSelected is true when annual package exists`() {
+        assertTrue(defaultIsAnnualSelected(listOf(product(PlanType.MONTHLY), product(PlanType.ANNUAL))))
+    }
+
+    @Test
+    fun `defaultIsAnnualSelected is false when annual package is absent`() {
+        assertFalse(defaultIsAnnualSelected(listOf(product(PlanType.MONTHLY))))
+    }
+
+    @Test
+    fun `defaultIsAnnualSelected is false for empty product list`() {
+        assertFalse(defaultIsAnnualSelected(emptyList()))
+    }
+}


### PR DESCRIPTION
## 概要
#182 対応。`PaywallScreen.kt` の `PlanSelector`/`selectedProduct` 分岐（年額パッケージ有無によるデフォルト選択・月額単一UIへのフォールバック）にテストが無かった問題。

## 変更内容
- `BillingContent` 内にインラインで書かれていた分岐ロジックを `resolvePaywallPlansUiState()` / `defaultIsAnnualSelected()` として抽出（`PaywallPlansUiState` sealed class: `Unavailable` / `SinglePlan` / `DualPlan`）
- 抽出したロジックを実際の`BillingContent`から呼び出す形に置き換え（ロジックとUIの二重管理を避けるため）
- `PaywallScreenTest.kt` を新規追加し、以下をカバー:
  - 年額パッケージが存在する場合のデフォルト選択状態（年額がデフォルト選択）
  - 年額パッケージが取得できない場合の月額単一UIへのフォールバック
  - 両方揃っている場合の選択状態切り替え(`selectedProduct`)
  - MONTHLY種別が無い場合に先頭商品を月額枠として扱う既存フォールバック挙動

UI自体の見た目・分岐条件は変更していません（ロジックの抽出のみ）。

## 検証結果（ハーネス）
- `./gradlew assembleDebug` ✅
- `./gradlew testDebugUnitTest` ✅（新規9テスト含め全green）
- `./gradlew lintDebug` ✅（新規/変更ファイルへの指摘なし）

Closes #182