### PR TITLE
feat(ios): 文字起こし要約をFoundation Modelsでオンデバイス化 (#188)

### DIFF
--- a/ios/VoiLog/Transcription/MeetingMinutesFeature.swift
+++ b/ios/VoiLog/Transcription/MeetingMinutesFeature.swift
@@ -15,7 +15,7 @@ struct MeetingMinutesClient: Sendable {
     var generate: @Sendable (String) async throws -> MeetingMinutesResult
 }
 
-enum MeetingMinutesError: Error, LocalizedError {
+enum MeetingMinutesError: Error, LocalizedError, Equatable {
     case unavailable
     case noTranscriptionText
     case modelUnavailable
@@ -37,13 +37,20 @@ enum MeetingMinutesError: Error, LocalizedError {
 
 extension MeetingMinutesClient: DependencyKey {
     static let liveValue = MeetingMinutesClient(generate: { text in
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw MeetingMinutesError.noTranscriptionText
-        }
-        guard #available(iOS 26, *) else {
-            throw MeetingMinutesError.unavailable
-        }
-        return try await generateWithFoundationModels(text)
+        try await MeetingMinutesGenerator.generate(
+            text: text,
+            isOnDeviceAvailable: {
+                guard #available(iOS 26, *) else { return false }
+                return SystemLanguageModel.default.isAvailable
+            },
+            onDevice: { text in
+                guard #available(iOS 26, *) else { throw MeetingMinutesError.unavailable }
+                return try await generateWithFoundationModels(text)
+            },
+            cloudFallback: { text in
+                try await MeetingMinutesCloudFallback().generate(text: text)
+            }
+        )
     })
 
     static let testValue = MeetingMinutesClient(generate: { _ in
@@ -52,6 +59,50 @@ extension MeetingMinutesClient: DependencyKey {
             todos: ["TODO 1", "TODO 2"]
         )
     })
+}
+
+/// オンデバイス（Foundation Models）が使えるかどうかで処理を振り分ける純粋なロジック。
+///
+/// 実際の `SystemLanguageModel`/ネットワーク呼び出しは呼び出し元からクロージャとして注入するため、
+/// このロジック自体はモックだけで（実機のApple Intelligence状態に依存せず）テストできる。
+enum MeetingMinutesGenerator {
+    static func generate(
+        text: String,
+        isOnDeviceAvailable: () -> Bool,
+        onDevice: (String) async throws -> MeetingMinutesResult,
+        cloudFallback: (String) async throws -> MeetingMinutesResult
+    ) async throws -> MeetingMinutesResult {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw MeetingMinutesError.noTranscriptionText
+        }
+        guard isOnDeviceAvailable() else {
+            return try await cloudFallback(text)
+        }
+        return try await onDevice(text)
+    }
+}
+
+/// オンデバイス（Foundation Models）が非対応の環境向けに、既存のクラウドAPI（Gemini `/minutes`）で
+/// 議事録要約を生成するフォールバック。
+struct MeetingMinutesCloudFallback {
+    @Dependency(\.transcriptionClient) var transcriptionClient
+    @Dependency(\.firebaseAuthClient) var firebaseAuth
+
+    func generate(text: String) async throws -> MeetingMinutesResult {
+        let language = TranscriptionFeature.State.detectLanguage()
+        do {
+            let idToken = try await firebaseAuth.currentUserIDToken(false)
+            let (response, _) = try await withAuthRetry(
+                firebaseAuth: firebaseAuth,
+                currentToken: idToken
+            ) { token in
+                try await transcriptionClient.generateMinutes(token, text, language)
+            }
+            return MeetingMinutesResult(summary: response.summary, todos: response.todos)
+        } catch {
+            throw MeetingMinutesError.generationFailed(error.localizedDescription)
+        }
+    }
 }
 
 extension DependencyValues {

--- a/ios/VoiLog/Transcription/TranscriptionFeature.swift
+++ b/ios/VoiLog/Transcription/TranscriptionFeature.swift
@@ -36,6 +36,7 @@ struct TranscriptionClient {
     var uploadURL: @Sendable (_ idToken: String, _ ext: String) async throws -> UploadURLResponse
     var transcribe: @Sendable (_ idToken: String, _ blobName: String, _ language: String) async throws -> TranscriptionResponse
     var uploadAudio: @Sendable (_ fileURL: URL, _ signedURL: String, _ mimeType: String) async throws -> Void
+    var generateMinutes: @Sendable (_ idToken: String, _ text: String, _ language: String) async throws -> MinutesResponse
 
     struct UploadURLResponse: Decodable {
         let uploadUrl: String
@@ -53,6 +54,12 @@ struct TranscriptionClient {
             let speaker: String?
             let text: String
         }
+    }
+
+    /// `/minutes`（オンデバイスFoundation Modelsが使えない環境向けのクラウドフォールバック）のレスポンス
+    struct MinutesResponse: Decodable {
+        let summary: String
+        let todos: [String]
     }
 }
 
@@ -133,6 +140,27 @@ extension TranscriptionClient: DependencyKey {
             guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
                 let code = (response as? HTTPURLResponse)?.statusCode ?? -1
                 throw TranscriptionError.uploadFailed(code)
+            }
+        },
+        generateMinutes: { idToken, text, language in
+            let url = URL(string: "\(serverBaseURL)/minutes")!
+            var req = URLRequest(url: url)
+            req.httpMethod = "POST"
+            req.setValue("Bearer \(idToken)", forHTTPHeaderField: "Authorization")
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            req.httpBody = try JSONEncoder().encode(["text": text, "language": language])
+            req.timeoutInterval = 120
+            let (data, response) = try await URLSession.shared.data(for: req)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            guard (200..<300).contains(status) else {
+                let body = String(data: data, encoding: .utf8) ?? "no body"
+                throw TranscriptionError.serverError(status, body)
+            }
+            do {
+                return try JSONDecoder().decode(MinutesResponse.self, from: data)
+            } catch {
+                let body = String(data: data, encoding: .utf8) ?? "no body"
+                throw TranscriptionError.serverError(0, "decode failed: \(body)")
             }
         }
     )

--- a/ios/VoiLogTests/MeetingMinutesClientTests.swift
+++ b/ios/VoiLogTests/MeetingMinutesClientTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+import ComposableArchitecture
+@testable import VoiLog
+
+// MARK: - MeetingMinutesGenerator (オンデバイス/クラウドフォールバックの振り分けロジック)
+
+final class MeetingMinutesGeneratorTests: XCTestCase {
+
+    func testGenerate_emptyText_throwsWithoutCallingEitherPath() async {
+        let onDeviceCalled = LockIsolated(false)
+        let cloudCalled = LockIsolated(false)
+
+        do {
+            _ = try await MeetingMinutesGenerator.generate(
+                text: "   ",
+                isOnDeviceAvailable: { true },
+                onDevice: { _ in
+                    onDeviceCalled.setValue(true)
+                    return MeetingMinutesResult(summary: "", todos: [])
+                },
+                cloudFallback: { _ in
+                    cloudCalled.setValue(true)
+                    return MeetingMinutesResult(summary: "", todos: [])
+                }
+            )
+            XCTFail("空文字はエラーになるはず")
+        } catch {
+            XCTAssertEqual(error as? MeetingMinutesError, .noTranscriptionText)
+        }
+
+        XCTAssertFalse(onDeviceCalled.value)
+        XCTAssertFalse(cloudCalled.value)
+    }
+
+    func testGenerate_onDeviceAvailable_usesOnDeviceNotCloud() async throws {
+        let cloudCalled = LockIsolated(false)
+        let expected = MeetingMinutesResult(summary: "オンデバイス要約", todos: ["TODO"])
+
+        let result = try await MeetingMinutesGenerator.generate(
+            text: "会議の文字起こし",
+            isOnDeviceAvailable: { true },
+            onDevice: { _ in expected },
+            cloudFallback: { _ in
+                cloudCalled.setValue(true)
+                return MeetingMinutesResult(summary: "", todos: [])
+            }
+        )
+
+        XCTAssertEqual(result, expected)
+        XCTAssertFalse(cloudCalled.value, "オンデバイスが使えるならクラウドは呼ばれないはず")
+    }
+
+    func testGenerate_onDeviceUnavailable_fallsBackToCloud() async throws {
+        let onDeviceCalled = LockIsolated(false)
+        let expected = MeetingMinutesResult(summary: "クラウド要約", todos: [])
+
+        let result = try await MeetingMinutesGenerator.generate(
+            text: "会議の文字起こし",
+            isOnDeviceAvailable: { false },
+            onDevice: { _ in
+                onDeviceCalled.setValue(true)
+                return MeetingMinutesResult(summary: "", todos: [])
+            },
+            cloudFallback: { _ in expected }
+        )
+
+        XCTAssertEqual(result, expected)
+        XCTAssertFalse(onDeviceCalled.value, "オンデバイスが非対応ならオンデバイス実装は呼ばれないはず")
+    }
+
+    func testGenerate_onDeviceThrows_propagatesWithoutFallingBackToCloud() async {
+        let cloudCalled = LockIsolated(false)
+
+        do {
+            _ = try await MeetingMinutesGenerator.generate(
+                text: "会議の文字起こし",
+                isOnDeviceAvailable: { true },
+                onDevice: { _ in throw MeetingMinutesError.generationFailed("失敗") },
+                cloudFallback: { _ in
+                    cloudCalled.setValue(true)
+                    return MeetingMinutesResult(summary: "", todos: [])
+                }
+            )
+            XCTFail("エラーが伝播するはず")
+        } catch {
+            XCTAssertEqual(error as? MeetingMinutesError, .generationFailed("失敗"))
+        }
+
+        XCTAssertFalse(cloudCalled.value, "生成失敗は非対応と異なりクラウドへフォールバックしない")
+    }
+}
+
+// MARK: - MeetingMinutesCloudFallback (クラウドAPI経由の議事録生成)
+
+@MainActor
+final class MeetingMinutesCloudFallbackTests: XCTestCase {
+
+    private func makeFallback(
+        generateMinutes: @escaping @Sendable (String, String, String) async throws -> TranscriptionClient.MinutesResponse,
+        currentUserIDToken: @escaping @Sendable (Bool) async throws -> String = { _ in "test-token" }
+    ) -> MeetingMinutesCloudFallback {
+        withDependencies {
+            $0.transcriptionClient = TranscriptionClient(
+                uploadURL: { _, _ in .init(uploadUrl: "", fileId: "", blobName: "") },
+                transcribe: { _, _, _ in .init(transcription: "", segments: nil, summary: nil) },
+                uploadAudio: { _, _, _ in },
+                generateMinutes: generateMinutes
+            )
+            $0.firebaseAuthClient = FirebaseAuthClient(currentUserIDToken: currentUserIDToken)
+        } operation: {
+            MeetingMinutesCloudFallback()
+        }
+    }
+
+    func testGenerate_success_mapsResponseToResult() async throws {
+        let fallback = makeFallback(
+            generateMinutes: { _, _, _ in .init(summary: "クラウド要約", todos: ["TODO A", "TODO B"]) }
+        )
+
+        let result = try await fallback.generate(text: "会議の文字起こし")
+
+        XCTAssertEqual(result.summary, "クラウド要約")
+        XCTAssertEqual(result.todos, ["TODO A", "TODO B"])
+    }
+
+    func testGenerate_uploadURL401_retriesWithForcedRefreshToken() async throws {
+        let fallback = makeFallback(
+            generateMinutes: { token, _, _ in
+                if token == "stale-token" {
+                    throw TranscriptionError.serverError(401, "Unauthorized")
+                }
+                return .init(summary: "再試行成功", todos: [])
+            },
+            currentUserIDToken: { forcingRefresh in forcingRefresh ? "fresh-token" : "stale-token" }
+        )
+
+        let result = try await fallback.generate(text: "会議の文字起こし")
+
+        XCTAssertEqual(result.summary, "再試行成功")
+    }
+
+    func testGenerate_serverError_throwsGenerationFailed() async {
+        let fallback = makeFallback(
+            generateMinutes: { _, _, _ in throw TranscriptionError.serverError(500, "Internal Server Error") }
+        )
+
+        do {
+            _ = try await fallback.generate(text: "会議の文字起こし")
+            XCTFail("サーバーエラーはgenerationFailedとして伝播するはず")
+        } catch {
+            guard case .generationFailed = error as? MeetingMinutesError else {
+                XCTFail("Expected .generationFailed but got \(error)")
+                return
+            }
+        }
+    }
+}

--- a/ios/VoiLogTests/TranscriptionFeatureTests.swift
+++ b/ios/VoiLogTests/TranscriptionFeatureTests.swift
@@ -16,6 +16,9 @@ final class TranscriptionFeatureTests: XCTestCase {
             .init(transcription: "テスト文章", segments: nil, summary: nil)
         },
         uploadAudio: @escaping @Sendable (URL, String, String) async throws -> Void = { _, _, _ in },
+        generateMinutes: @escaping @Sendable (String, String, String) async throws -> TranscriptionClient.MinutesResponse = { _, _, _ in
+            .init(summary: "テスト議事録", todos: [])
+        },
         currentUserIDToken: @escaping @Sendable (Bool) async throws -> String = { _ in "test-token" }
     ) -> TestStore<TranscriptionFeature.State, TranscriptionFeature.Action> {
         TestStore(
@@ -26,7 +29,8 @@ final class TranscriptionFeatureTests: XCTestCase {
             $0.transcriptionClient = TranscriptionClient(
                 uploadURL: uploadURL,
                 transcribe: transcribe,
-                uploadAudio: uploadAudio
+                uploadAudio: uploadAudio,
+                generateMinutes: generateMinutes
             )
             $0.firebaseAuthClient = FirebaseAuthClient(currentUserIDToken: currentUserIDToken)
         }


### PR DESCRIPTION
## Summary
- issue #188 の完了条件（オンデバイスで要約実行 + 非対応環境ではクラウドAPIにフォールバック）を満たす (closes #188)

## 事前調査で分かったこと（issue本文との差分）
issueの「現状」はクラウドAPI（Gemini）で要約している前提だったが、実際には既に別コミット（`d7ec5baa` feat: add AI meeting minutes generation using Apple Intelligence）で `MeetingMinutesFeature`/`MeetingMinutesClient` がオンデバイスFoundation Modelsで議事録要約（summary+todos）を生成する実装済みだった。ただし非対応環境では単にエラーを投げるだけで、「クラウドAPIへのフォールバック」が未実装だった。
また、サーバー側（`server/transcription/main.go`）には既に `/minutes` エンドポイント（Gemini経由でsummary+todosを返す、server-v1.2.0で追加）が存在していたが、iOSクライアントからは一度も呼ばれていなかった。今回この2つを繋いだ。

## 変更内容
- `TranscriptionClient` に `generateMinutes(idToken:text:language:)` を追加し、既存の `/minutes` サーバーエンドポイントを呼べるようにした
- `MeetingMinutesClient.liveValue`: オンデバイス（`SystemLanguageModel.default.isAvailable`）が使えるときはそのままFoundation Modelsで生成、使えない（iOS 26未満・Apple Intelligence無効・モデル未準備）ときは `/minutes` 経由のクラウドAPIにフォールバック。結果の型（`MeetingMinutesResult(summary:todos:)`）・呼び出しインターフェースは変更なし
- オンデバイス/クラウドの振り分けロジックを `MeetingMinutesGenerator`（純粋関数）に切り出し、実機のApple Intelligence状態に依存せずユニットテストできるようにした
- 生成自体の失敗（オンデバイス・クラウドどちらも）はフォールバックせずそのままエラー伝播する（あくまで「非対応環境へのフォールバック」であり「生成失敗時のリトライ」ではない、という設計）

## テスト
- `ios/VoiLogTests/MeetingMinutesClientTests.swift`（新規）
  - `MeetingMinutesGeneratorTests`: 空文字エラー・オンデバイス優先・非対応時のクラウドフォールバック・生成失敗時は非フォールバックを検証
  - `MeetingMinutesCloudFallbackTests`: クラウド `/minutes` 呼び出しの成功・401リトライ・サーバーエラー時の `generationFailed` 伝播を検証
- `ios/VoiLogTests/TranscriptionFeatureTests.swift`: `TranscriptionClient` に追加した `generateMinutes` パラメータに対応

## Test plan
- [x] `xcodebuild build -project VoiLog.xcodeproj -scheme VoiLogDevelop -configuration Debug -destination 'generic/platform=iOS Simulator'` → BUILD SUCCEEDED
- [x] `xcodebuild test -project VoiLog.xcodeproj -scheme VoiLogTests -destination 'platform=iOS Simulator,id=<iPhone 16 Pro Max>'` → TEST SUCCEEDED
- [x] `swiftlint --fix && swiftlint` → 0 serious violations
- [ ] 実機/シミュレータでのオンデバイス要約実行確認、および非対応環境（Apple Intelligence無効化した実機等）でのクラウドフォールバック確認（レビュー後に実施予定）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01GgAmbWPPqeuNXUJwBe8AeF