### PR TITLE
feat(ios): NowPlayingフレームワークでロック画面/コントロールセンター再生連携 (#190)

### DIFF
--- a/ios/VoiLog/AppEnvironment.swift
+++ b/ios/VoiLog/AppEnvironment.swift
@@ -1,0 +1,19 @@
+//
+//  AppEnvironment.swift
+//  VoiLog
+//
+
+import ComposableArchitecture
+
+/// アプリ全体で共有する `VoiceAppFeature` の Store。
+///
+/// ロック画面/コントロールセンターからの再生操作（MPRemoteCommandCenter）や
+/// ライブアクティビティのボタン操作、App Intents（Shortcuts/Siri経由）は
+/// SwiftUI の View 階層を経由せずに実行されるため、同じ Store インスタンスに
+/// 直接アクションを送れるようこの静的プロパティを介して公開する。
+enum AppEnvironment {
+    @MainActor
+    static let store = Store(initialState: VoiceAppFeature.State()) {
+        VoiceAppFeature()
+    }
+}

--- a/ios/VoiLog/AudioPlayer.swift
+++ b/ios/VoiLog/AudioPlayer.swift
@@ -16,6 +16,10 @@ struct AudioPlayerClient {
     var play: @Sendable (URL, Double, AudioPlayerClient.PlaybackSpeed, Bool, Float) async throws -> Bool
     var stop: @Sendable () async throws -> Bool
     var getCurrentTime: @Sendable () async throws -> TimeInterval
+    /// 現在の再生位置を保持したまま一時停止する（ロック画面/コントロールセンターの一時停止用）。
+    var pause: @Sendable () async -> Void = {}
+    /// `pause()` で止めた位置から再生を再開する（新しく読み込み直さない）。
+    var resume: @Sendable () async -> Void = {}
 }
 
 extension AudioPlayerClient {
@@ -37,13 +41,17 @@ extension AudioPlayerClient: TestDependencyKey {
         },
         getCurrentTime: {
             60
-        }
+        },
+        pause: {},
+        resume: {}
     )
 
     static let testValue = Self(
         play: unimplemented("\(Self.self).play"),
         stop: unimplemented("\(Self.self).stop"),
-        getCurrentTime: unimplemented("\(Self.self).getCurrentTime")
+        getCurrentTime: unimplemented("\(Self.self).getCurrentTime"),
+        pause: unimplemented("\(Self.self).pause"),
+        resume: unimplemented("\(Self.self).resume")
     )
 }
 extension DependencyValues {
@@ -66,6 +74,12 @@ extension AudioPlayerClient: DependencyKey {
             },
             getCurrentTime: {
                 await audioPlayer.getCurrentTime()
+            },
+            pause: {
+                await audioPlayer.pause()
+            },
+            resume: {
+                await audioPlayer.resume()
             }
         )
     }
@@ -133,6 +147,14 @@ private actor AudioPlayer {
         guard let player = player else { return false }
         player.stop()
         return true
+    }
+
+    func pause() {
+        player?.pause()
+    }
+
+    func resume() {
+        player?.play()
     }
 
     func getCurrentTime() async -> TimeInterval {

--- a/ios/VoiLog/Playback/NowPlayingClient.swift
+++ b/ios/VoiLog/Playback/NowPlayingClient.swift
@@ -1,0 +1,51 @@
+//
+//  NowPlayingClient.swift
+//  VoiLog
+//
+//  ロック画面/コントロールセンターの再生情報表示（issue #190）。
+//  MPNowPlayingInfoCenterはiOS 4以来の安定APIで、Xcode 27 beta(iOS 27 SDK)専用の
+//  新しい `NowPlaying` フレームワークは現行の安定版Xcodeではビルドできないため使わない。
+//
+
+import ComposableArchitecture
+import Foundation
+import MediaPlayer
+
+struct NowPlayingInfo: Equatable, Sendable {
+    var title: String
+    var duration: TimeInterval
+    var elapsedTime: TimeInterval
+    var isPlaying: Bool
+}
+
+struct NowPlayingClient {
+    /// `nil` を渡すとロック画面/コントロールセンターの再生情報を消去する。
+    var update: @Sendable (NowPlayingInfo?) -> Void
+}
+
+extension NowPlayingClient: TestDependencyKey {
+    static let previewValue = Self(update: { _ in })
+    static let testValue = Self(update: unimplemented("\(Self.self).update"))
+}
+
+extension DependencyValues {
+    var nowPlayingClient: NowPlayingClient {
+        get { self[NowPlayingClient.self] }
+        set { self[NowPlayingClient.self] = newValue }
+    }
+}
+
+extension NowPlayingClient: DependencyKey {
+    static let liveValue = Self(update: { info in
+        guard let info else {
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+            return
+        }
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = [
+            MPMediaItemPropertyTitle: info.title,
+            MPMediaItemPropertyPlaybackDuration: info.duration,
+            MPNowPlayingInfoPropertyElapsedPlaybackTime: info.elapsedTime,
+            MPNowPlayingInfoPropertyPlaybackRate: info.isPlaying ? 1.0 : 0.0
+        ]
+    })
+}

--- a/ios/VoiLog/Playback/NowPlayingCommandCenter.swift
+++ b/ios/VoiLog/Playback/NowPlayingCommandCenter.swift
@@ -1,0 +1,46 @@
+//
+//  NowPlayingCommandCenter.swift
+//  VoiLog
+//
+//  ロック画面/コントロールセンターの再生/一時停止操作（MPRemoteCommandCenter）を
+//  PlaybackFeatureに伝える（issue #190）。
+//
+
+import ComposableArchitecture
+import MediaPlayer
+
+@MainActor
+final class NowPlayingCommandCenter {
+    static let shared = NowPlayingCommandCenter()
+
+    private var isConfigured = false
+
+    private init() {}
+
+    func configure(store: StoreOf<VoiceAppFeature> = AppEnvironment.store) {
+        guard !isConfigured else { return }
+        isConfigured = true
+
+        let commandCenter = MPRemoteCommandCenter.shared()
+
+        commandCenter.playCommand.addTarget { _ in
+            store.send(.playbackFeature(.nowPlayingCommand(.play)))
+            return .success
+        }
+        commandCenter.pauseCommand.addTarget { _ in
+            store.send(.playbackFeature(.nowPlayingCommand(.pause)))
+            return .success
+        }
+        commandCenter.togglePlayPauseCommand.addTarget { _ in
+            store.send(.playbackFeature(.nowPlayingCommand(.togglePlayPause)))
+            return .success
+        }
+        commandCenter.changePlaybackPositionCommand.addTarget { event in
+            guard let event = event as? MPChangePlaybackPositionCommandEvent else {
+                return .commandFailed
+            }
+            store.send(.playbackFeature(.nowPlayingCommand(.seek(event.positionTime))))
+            return .success
+        }
+    }
+}

--- a/ios/VoiLog/Playback/PlaybackFeature.swift
+++ b/ios/VoiLog/Playback/PlaybackFeature.swift
@@ -131,6 +131,16 @@ struct PlaybackFeature {
     case audioPlayerDidFinish
     case audioEditor(AudioEditorReducer.Action)
 
+    /// ロック画面/コントロールセンター（MPRemoteCommandCenter）からの操作。
+    case nowPlayingCommand(NowPlayingCommand)
+
+    enum NowPlayingCommand: Equatable, Sendable {
+      case play
+      case pause
+      case togglePlayPause
+      case seek(TimeInterval)
+    }
+
     @CasePathable
     enum View {
       case onAppear
@@ -219,6 +229,7 @@ struct PlaybackFeature {
   @Dependency(\.continuousClock) var clock
   @Dependency(\.voiceMemoRepository) var voiceMemoRepository
   @Dependency(\.rewardedAdClient) var rewardedAdClient
+  @Dependency(\.nowPlayingClient) var nowPlayingClient
 
   var body: some Reducer<State, Action> {
     BindingReducer()
@@ -254,6 +265,7 @@ struct PlaybackFeature {
             state.abLoopEnd = nil
 
             if let memo = state.voiceMemos.first(where: { $0.id == id }) {
+              publishNowPlayingInfo(memo: memo, elapsedTime: 0, isPlaying: true)
               return startPlayback(url: memo.url, playSpeed: state.playSpeed, volumeBoost: state.volumeBoost)
             }
           }
@@ -266,14 +278,23 @@ struct PlaybackFeature {
               state.playbackState = .idle
               state.currentPlayingMemo = nil
               state.currentTime = 0
+              nowPlayingClient.update(nil)
               return .merge(
                 .cancel(id: CancelID.playback),
                 .run { _ in try await audioPlayer.stop() }
               )
+            } else if state.playbackState == .paused {
+              // ロック画面等で一時停止していた場合は、同じ位置から再開する
+              state.playbackState = .playing
+              if let memo = state.voiceMemos.first(where: { $0.id == id }) {
+                publishNowPlayingInfo(memo: memo, elapsedTime: state.currentTime, isPlaying: true)
+              }
+              return .run { _ in await audioPlayer.resume() }
             } else {
               // 停止中の場合は再生開始
               state.playbackState = .playing
               if let memo = state.voiceMemos.first(where: { $0.id == id }) {
+                publishNowPlayingInfo(memo: memo, elapsedTime: 0, isPlaying: true)
                 return startPlayback(url: memo.url, playSpeed: state.playSpeed, volumeBoost: state.volumeBoost)
               }
             }
@@ -286,6 +307,7 @@ struct PlaybackFeature {
             state.abLoopEnd = nil
 
             if let memo = state.voiceMemos.first(where: { $0.id == id }) {
+              publishNowPlayingInfo(memo: memo, elapsedTime: 0, isPlaying: true)
               return startPlayback(url: memo.url, playSpeed: state.playSpeed, volumeBoost: state.volumeBoost)
             }
           }
@@ -297,6 +319,7 @@ struct PlaybackFeature {
           state.currentTime = 0
           state.abLoopStart = nil
           state.abLoopEnd = nil
+          nowPlayingClient.update(nil)
           return .merge(
             .cancel(id: CancelID.playback),
             .run { _ in try await audioPlayer.stop() }
@@ -644,7 +667,13 @@ struct PlaybackFeature {
         return .none
 
       case let .playbackTimeUpdated(time):
+        // ロック画面のNow Playing情報は1秒に1回だけ更新する（過剰な更新を避けるため）
+        let previousSecond = Int(state.currentTime)
         state.currentTime = time
+        if Int(time) != previousSecond,
+           let memo = state.voiceMemos.first(where: { $0.id == state.currentPlayingMemo }) {
+          publishNowPlayingInfo(memo: memo, elapsedTime: time, isPlaying: state.playbackState == .playing)
+        }
         // AB loop: seek back to A when current time reaches B
         if let loopStart = state.abLoopStart,
            let loopEnd = state.abLoopEnd,
@@ -658,13 +687,53 @@ struct PlaybackFeature {
         state.playbackState = .idle
         state.currentPlayingMemo = nil
         state.currentTime = 0
+        nowPlayingClient.update(nil)
         return .none
 
       case .audioPlayerDidFinish:
         if state.isRepeatOne, let memo = state.voiceMemos.first(where: { $0.id == state.currentPlayingMemo }) {
+          publishNowPlayingInfo(memo: memo, elapsedTime: 0, isPlaying: true)
           return startPlayback(url: memo.url, startTime: 0, playSpeed: state.playSpeed, volumeBoost: state.volumeBoost)
         }
         return .send(.playbackFinished)
+
+      case let .nowPlayingCommand(command):
+        switch command {
+        case .play:
+          guard state.playbackState == .paused else { return .none }
+          state.playbackState = .playing
+          if let memo = state.voiceMemos.first(where: { $0.id == state.currentPlayingMemo }) {
+            publishNowPlayingInfo(memo: memo, elapsedTime: state.currentTime, isPlaying: true)
+          }
+          return .run { _ in await audioPlayer.resume() }
+
+        case .pause:
+          guard state.playbackState == .playing else { return .none }
+          state.playbackState = .paused
+          if let memo = state.voiceMemos.first(where: { $0.id == state.currentPlayingMemo }) {
+            publishNowPlayingInfo(memo: memo, elapsedTime: state.currentTime, isPlaying: false)
+          }
+          return .run { _ in await audioPlayer.pause() }
+
+        case .togglePlayPause:
+          switch state.playbackState {
+          case .playing:
+            return .send(.nowPlayingCommand(.pause))
+          case .paused:
+            return .send(.nowPlayingCommand(.play))
+          case .idle:
+            return .none
+          }
+
+        case let .seek(time):
+          guard state.currentPlayingMemo != nil else { return .none }
+          state.currentTime = time
+          if let memo = state.voiceMemos.first(where: { $0.id == state.currentPlayingMemo }) {
+            publishNowPlayingInfo(memo: memo, elapsedTime: time, isPlaying: state.playbackState == .playing)
+            return startPlayback(url: memo.url, startTime: time, playSpeed: state.playSpeed, volumeBoost: state.volumeBoost)
+          }
+          return .none
+        }
 
       case .audioEditor(.save):
         // 編集完了時にPlaybackFeatureのデータを更新
@@ -727,6 +796,13 @@ struct PlaybackFeature {
 
       await send(.memosLoaded(memos))
     }
+  }
+
+  /// ロック画面/コントロールセンターのNow Playing情報を更新する。
+  private func publishNowPlayingInfo(memo: VoiceMemo, elapsedTime: TimeInterval, isPlaying: Bool) {
+    nowPlayingClient.update(
+      NowPlayingInfo(title: memo.title, duration: memo.duration, elapsedTime: elapsedTime, isPlaying: isPlaying)
+    )
   }
 
   private func startPlayback(url: URL, startTime: TimeInterval = 0, playSpeed: AudioPlayerClient.PlaybackSpeed = .normal, volumeBoost: Float = 1.0) -> Effect<Action> {

--- a/ios/VoiLog/VoiceMemoApp.swift
+++ b/ios/VoiLog/VoiceMemoApp.swift
@@ -30,6 +30,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         FirebaseApp.configure()
         Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
 
+        // ロック画面/コントロールセンターからの再生操作を受け取る
+        NowPlayingCommandCenter.shared.configure()
+
         // AdMob初期化を遅延実行（UIが表示された後）
         #if !DEBUG
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
@@ -119,9 +122,7 @@ struct VoiceMemoApp: App {
                 }
             } else {
                 VoiceAppView(
-                    store: Store(initialState: VoiceAppFeature.State()) {
-                        VoiceAppFeature()
-                    },
+                    store: AppEnvironment.store,
                     recordAdmobUnitId: recordAdmobUnitId,
                     playListAdmobUnitId: playListAdmobUnitId,
                     admobUnitId: admobUnitId

--- a/ios/VoiLogTests/PlaybackFeatureTests.swift
+++ b/ios/VoiLogTests/PlaybackFeatureTests.swift
@@ -131,6 +131,7 @@ final class PlaybackFeatureTests: XCTestCase {
                     stop: { true },
                     getCurrentTime: { 0 }
                 )
+                $0.nowPlayingClient = NowPlayingClient(update: { _ in })
             }
 
             await store.send(.audioPlayerDidFinish)
@@ -159,6 +160,7 @@ final class PlaybackFeatureTests: XCTestCase {
                     stop: { true },
                     getCurrentTime: { 0 }
                 )
+                $0.nowPlayingClient = NowPlayingClient(update: { _ in })
             }
 
             await store.send(.audioPlayerDidFinish)
@@ -197,6 +199,7 @@ final class PlaybackFeatureTests: XCTestCase {
                 stop: { true },
                 getCurrentTime: { 0 }
             )
+            $0.nowPlayingClient = NowPlayingClient(update: { _ in })
         }
         store.exhaustivity = .off
 
@@ -516,6 +519,264 @@ final class PlaybackFeatureTests: XCTestCase {
             }
 
             await store.send(.view(.volumeBoostApplied))
+        }
+    }
+
+    // MARK: - nowPlayingCommand: ロック画面/コントロールセンターからの操作（issue #190）
+
+    func testNowPlayingCommand_pause_whilePlaying_pausesAndUpdatesNowPlaying() async {
+        await withMainSerialExecutor {
+            var initial = PlaybackFeature.State()
+            initial.voiceMemos = [makeMemo()]
+            initial.currentPlayingMemo = testID
+            initial.playbackState = .playing
+            initial.currentTime = 3.5
+
+            let pauseCalled = LockIsolated(false)
+            let publishedInfo = LockIsolated<[NowPlayingInfo?]>([])
+
+            let store = TestStore(initialState: initial) {
+                PlaybackFeature()
+            } withDependencies: {
+                $0.voiceMemoRepository = mockRepository()
+                $0.audioPlayer = AudioPlayerClient(
+                    play: { _, _, _, _, _ in true },
+                    stop: { true },
+                    getCurrentTime: { 0 },
+                    pause: { pauseCalled.setValue(true) },
+                    resume: {}
+                )
+                $0.nowPlayingClient = NowPlayingClient(update: { info in
+                    publishedInfo.withValue { $0.append(info) }
+                })
+            }
+
+            await store.send(.nowPlayingCommand(.pause)) {
+                $0.playbackState = .paused
+            }
+
+            XCTAssertTrue(pauseCalled.value)
+            XCTAssertEqual(publishedInfo.value.last??.isPlaying, false)
+            XCTAssertEqual(publishedInfo.value.last??.elapsedTime, 3.5)
+        }
+    }
+
+    func testNowPlayingCommand_pause_whileIdle_doesNothing() async {
+        await withMainSerialExecutor {
+            let store = TestStore(initialState: PlaybackFeature.State()) {
+                PlaybackFeature()
+            } withDependencies: {
+                $0.voiceMemoRepository = mockRepository()
+                $0.audioPlayer = AudioPlayerClient(
+                    play: { _, _, _, _, _ in true },
+                    stop: { true },
+                    getCurrentTime: { 0 },
+                    pause: { XCTFail("再生していない時にpauseが呼ばれてはいけない") },
+                    resume: {}
+                )
+            }
+
+            await store.send(.nowPlayingCommand(.pause))
+        }
+    }
+
+    func testNowPlayingCommand_play_whilePaused_resumesFromSamePosition() async {
+        await withMainSerialExecutor {
+            var initial = PlaybackFeature.State()
+            initial.voiceMemos = [makeMemo()]
+            initial.currentPlayingMemo = testID
+            initial.playbackState = .paused
+            initial.currentTime = 3.5
+
+            let resumeCalled = LockIsolated(false)
+
+            let store = TestStore(initialState: initial) {
+                PlaybackFeature()
+            } withDependencies: {
+                $0.voiceMemoRepository = mockRepository()
+                $0.audioPlayer = AudioPlayerClient(
+                    play: { _, _, _, _, _ in
+                        XCTFail("resumeはplayを呼び直さず、同じインスタンスをresumeするはず")
+                        return true
+                    },
+                    stop: { true },
+                    getCurrentTime: { 0 },
+                    pause: {},
+                    resume: { resumeCalled.setValue(true) }
+                )
+                $0.nowPlayingClient = NowPlayingClient(update: { _ in })
+            }
+
+            await store.send(.nowPlayingCommand(.play)) {
+                $0.playbackState = .playing
+            }
+
+            XCTAssertTrue(resumeCalled.value)
+            XCTAssertEqual(store.state.currentTime, 3.5, "位置がリセットされず再開されるはず")
+        }
+    }
+
+    func testNowPlayingCommand_play_whileIdle_doesNothing() async {
+        await withMainSerialExecutor {
+            let store = TestStore(initialState: PlaybackFeature.State()) {
+                PlaybackFeature()
+            } withDependencies: {
+                $0.voiceMemoRepository = mockRepository()
+                $0.audioPlayer = AudioPlayerClient(
+                    play: { _, _, _, _, _ in true },
+                    stop: { true },
+                    getCurrentTime: { 0 },
+                    pause: {},
+                    resume: { XCTFail("再生していない時にresumeが呼ばれてはいけない") }
+                )
+            }
+
+            await store.send(.nowPlayingCommand(.play))
+        }
+    }
+
+    func testNowPlayingCommand_togglePlayPause_whilePlaying_sendsPause() async {
+        await withMainSerialExecutor {
+            var initial = PlaybackFeature.State()
+            initial.voiceMemos = [makeMemo()]
+            initial.currentPlayingMemo = testID
+            initial.playbackState = .playing
+
+            let store = TestStore(initialState: initial) {
+                PlaybackFeature()
+            } withDependencies: {
+                $0.voiceMemoRepository = mockRepository()
+                $0.audioPlayer = AudioPlayerClient(
+                    play: { _, _, _, _, _ in true },
+                    stop: { true },
+                    getCurrentTime: { 0 },
+                    pause: {},
+                    resume: {}
+                )
+                $0.nowPlayingClient = NowPlayingClient(update: { _ in })
+            }
+
+            await store.send(.nowPlayingCommand(.togglePlayPause))
+            await store.receive(\.nowPlayingCommand) {
+                $0.playbackState = .paused
+            }
+        }
+    }
+
+    func testNowPlayingCommand_togglePlayPause_whilePaused_sendsPlay() async {
+        await withMainSerialExecutor {
+            var initial = PlaybackFeature.State()
+            initial.voiceMemos = [makeMemo()]
+            initial.currentPlayingMemo = testID
+            initial.playbackState = .paused
+
+            let store = TestStore(initialState: initial) {
+                PlaybackFeature()
+            } withDependencies: {
+                $0.voiceMemoRepository = mockRepository()
+                $0.audioPlayer = AudioPlayerClient(
+                    play: { _, _, _, _, _ in true },
+                    stop: { true },
+                    getCurrentTime: { 0 },
+                    pause: {},
+                    resume: {}
+                )
+                $0.nowPlayingClient = NowPlayingClient(update: { _ in })
+            }
+
+            await store.send(.nowPlayingCommand(.togglePlayPause))
+            await store.receive(\.nowPlayingCommand) {
+                $0.playbackState = .playing
+            }
+        }
+    }
+
+    func testNowPlayingCommand_seek_whileNothingPlaying_doesNothing() async {
+        await withMainSerialExecutor {
+            let store = TestStore(initialState: PlaybackFeature.State()) {
+                PlaybackFeature()
+            } withDependencies: {
+                $0.voiceMemoRepository = mockRepository()
+                $0.audioPlayer = AudioPlayerClient(
+                    play: { _, _, _, _, _ in
+                        XCTFail("再生していない時にplayが呼ばれてはいけない")
+                        return true
+                    },
+                    stop: { true },
+                    getCurrentTime: { 0 }
+                )
+            }
+
+            await store.send(.nowPlayingCommand(.seek(10)))
+        }
+    }
+
+    func testPlayPauseButtonTapped_whilePaused_resumesInsteadOfRestarting() async {
+        await withMainSerialExecutor {
+            var initial = PlaybackFeature.State()
+            initial.voiceMemos = [makeMemo()]
+            initial.currentPlayingMemo = testID
+            initial.playbackState = .paused
+            initial.currentTime = 2.0
+
+            let resumeCalled = LockIsolated(false)
+
+            let store = TestStore(initialState: initial) {
+                PlaybackFeature()
+            } withDependencies: {
+                $0.voiceMemoRepository = mockRepository()
+                $0.audioPlayer = AudioPlayerClient(
+                    play: { _, _, _, _, _ in
+                        XCTFail("一時停止からの再開はplayを呼び直してはいけない")
+                        return true
+                    },
+                    stop: { true },
+                    getCurrentTime: { 0 },
+                    pause: {},
+                    resume: { resumeCalled.setValue(true) }
+                )
+                $0.nowPlayingClient = NowPlayingClient(update: { _ in })
+            }
+
+            await store.send(.view(.playPauseButtonTapped(testID))) {
+                $0.playbackState = .playing
+            }
+
+            XCTAssertTrue(resumeCalled.value)
+            XCTAssertEqual(store.state.currentTime, 2.0, "位置がリセットされないはず")
+        }
+    }
+
+    func testStopButtonTapped_clearsNowPlayingInfo() async {
+        await withMainSerialExecutor {
+            var initial = PlaybackFeature.State()
+            initial.voiceMemos = [makeMemo()]
+            initial.currentPlayingMemo = testID
+            initial.playbackState = .playing
+
+            let clearedCount = LockIsolated(0)
+
+            let store = TestStore(initialState: initial) {
+                PlaybackFeature()
+            } withDependencies: {
+                $0.voiceMemoRepository = mockRepository()
+                $0.audioPlayer = AudioPlayerClient(
+                    play: { _, _, _, _, _ in true },
+                    stop: { true },
+                    getCurrentTime: { 0 }
+                )
+                $0.nowPlayingClient = NowPlayingClient(update: { info in
+                    if info == nil { clearedCount.withValue { $0 += 1 } }
+                })
+            }
+
+            await store.send(.view(.stopButtonTapped)) {
+                $0.playbackState = .idle
+                $0.currentPlayingMemo = nil
+                $0.currentTime = 0
+            }
+
+            XCTAssertEqual(clearedCount.value, 1)
         }
     }
 }

--- a/ios/VoiLogTests/VoiceAppFeatureTests.swift
+++ b/ios/VoiLogTests/VoiceAppFeatureTests.swift
@@ -26,6 +26,7 @@ final class VoiceAppFeatureTests: XCTestCase {
                     stop: { true },
                     getCurrentTime: { 0 }
                 )
+                $0.nowPlayingClient = NowPlayingClient(update: { _ in })
             }
             store.exhaustivity = .off
 


### PR DESCRIPTION
## Summary
- issue #190 の完了条件を満たす (closes #190)

## 実装方針についての注記
issue本文が参照する新しい `NowPlaying` フレームワークは、確認したところ Xcode 27 beta (iOS 27 SDK) にしか存在せず、CIが使う安定版Xcodeではビルドできない（issue #187の`LongRunningIntent`等と同じ理由）。今回はiOS 4以来の安定APIである `MediaPlayer` フレームワーク（`MPNowPlayingInfoCenter`/`MPRemoteCommandCenter`）で実装した。機能的には同等（ロック画面/コントロールセンターへの再生情報表示・再生操作の受け取り）。

## 変更内容
- `NowPlayingClient`（新規, `ios/VoiLog/Playback/NowPlayingClient.swift`）: `MPNowPlayingInfoCenter` へタイトル・再生時間・経過時間・再生状態を反映する薄い `@Dependency`
- `NowPlayingCommandCenter`（新規, `ios/VoiLog/Playback/NowPlayingCommandCenter.swift`）: `MPRemoteCommandCenter` の再生/一時停止/トグル/シーク操作を、共有Store経由で `PlaybackFeature` に送る
- `PlaybackFeature` に `nowPlayingCommand`（`.play`/`.pause`/`.togglePlayPause`/`.seek`）アクションを追加
- 既存の `AudioPlayerClient` は `play`/`stop` のみで、一時停止しても再生位置がリセットされてしまう仕様だった（アプリ内の再生/一時停止ボタンも実質「毎回頭から再生し直す」動作）。ロック画面からの「一時停止→再開」で位置が保持されるよう、`AVAudioPlayer` のインスタンスを保持したまま一時停止/再開する `pause`/`resume` を追加した（デフォルト引数付きの追加のみなので既存の `play`/`stop` 呼び出し元は無変更）
- 副次的な一貫性のための修正: 一時停止中（ロック画面から一時停止した場合）にアプリ内の再生/一時停止ボタンを押すと、今までの「頭から再生し直す」動作ではなく同じ位置から再開するようにした。ロック画面操作とアプリ内操作の状態がズレないようにするための最小限の修正で、アプリ内ボタンの「再生中に押すと停止する」という既存動作自体は変更していない
- アプリ全体で共有する `Store` を持たせるため `AppEnvironment.swift` を追加（issue #187/#189と同じ課題への対応、同一内容なのでどのPRが先にマージされても自然に解決する想定）

## テスト
- `ios/VoiLogTests/PlaybackFeatureTests.swift`: `nowPlayingCommand` の play/pause/togglePlayPause/seek（再生中/非再生中それぞれ）、アプリ内ボタンでの一時停止からの再開、停止時のNow Playing情報クリアを追加
- 既存テストのうち `nowPlayingClient`（新規依存）を経由するようになった4件に `NowPlayingClient` のno-opスタブを追加（`PlaybackFeatureTests.swift` 3件, `VoiceAppFeatureTests.swift` 1件）

## Test plan
- [x] `xcodebuild build -project VoiLog.xcodeproj -scheme VoiLogDevelop -configuration Debug -destination 'generic/platform=iOS Simulator'` → BUILD SUCCEEDED
- [x] `xcodebuild test -project VoiLog.xcodeproj -scheme VoiLogTests -destination 'platform=iOS Simulator,id=<iPhone 16 Pro Max>'` → TEST SUCCEEDED
- [x] `swiftlint --fix && swiftlint` → 0 serious violations
- [ ] 実機/シミュレータでの動作確認（録音再生中にロック画面/コントロールセンターから一時停止・再開）はレビュー後に実施予定

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01GgAmbWPPqeuNXUJwBe8AeF