### PR TITLE
fix(transcription): bound hung Gemini connections so retries actually retry

### DIFF
--- a/server/transcription/main.go
+++ b/server/transcription/main.go
@@ -68,9 +68,31 @@ func initClients() {
 	if geminiAPIKey == "" {
 		log.Fatal("GEMINI_API_KEY is required")
 	}
-	geminiClient, err = genai.NewClient(ctx, option.WithAPIKey(geminiAPIKey))
+	geminiClient, err = genai.NewClient(ctx, option.WithAPIKey(geminiAPIKey), option.WithHTTPClient(newGeminiHTTPClient()))
 	if err != nil {
 		log.Fatalf("gemini client: %v", err)
+	}
+}
+
+// newGeminiHTTPClient は Gemini API 呼び出し用の http.Client を構築する。
+// 本番で観測された /transcribe 失敗は、成功リクエストが10〜20sで完了する一方
+// 失敗は例外なく親コンテキストの480sタイムアウトぴったりで発生しており、処理が
+// 遅いのではなく接続がハングして応答が返らないパターンだった。ResponseHeaderTimeout
+// を設定することで、ハングした試行を親コンテキストの残り時間いっぱい待たせず早期に
+// 失敗させ、generateContentWithRetry が新しいコネクションで実際にリトライできるようにする。
+// IdleConnTimeout は、NAT/LB 経由で無応答のまま片方だけ生き残ったアイドル接続の再利用を防ぐ。
+func newGeminiHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   10 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 120 * time.Second,
+			IdleConnTimeout:       90 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
 	}
 }
 
@@ -307,6 +329,9 @@ func generateContentWithRetry(ctx context.Context, timeout time.Duration, callGe
 
 // isTransientGeminiError は deadline exceeded・ネットワーク瞬断・Gemini側の5xx/429応答など
 // 再試行すれば成功しうる一時的なエラーかどうかを判定する。
+// net.Error は Timeout() の真偽に関わらず一時的なものとして扱う。
+// "read tcp ...: connection reset by peer" のような接続断は Timeout()==false だが、
+// 再送すれば成功しうる一時的なネットワークエラーであるため。
 func isTransientGeminiError(err error) bool {
 	if err == nil {
 		return false
@@ -315,7 +340,7 @@ func isTransientGeminiError(err error) bool {
 		return true
 	}
 	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
+	if errors.As(err, &netErr) {
 		return true
 	}
 	var apiErr *googleapi.Error

--- a/server/transcription/main_test.go
+++ b/server/transcription/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -222,6 +223,14 @@ func (fakeTimeoutError) Error() string   { return "fake timeout" }
 func (fakeTimeoutError) Timeout() bool   { return true }
 func (fakeTimeoutError) Temporary() bool { return true }
 
+// fakeConnResetError models a net.Error like "read tcp ...: connection reset by peer",
+// where Timeout() is false but the error is still a transient network failure.
+type fakeConnResetError struct{}
+
+func (fakeConnResetError) Error() string   { return "read tcp: connection reset by peer" }
+func (fakeConnResetError) Timeout() bool   { return false }
+func (fakeConnResetError) Temporary() bool { return false }
+
 func TestIsTransientGeminiError(t *testing.T) {
 	tests := []struct {
 		name string
@@ -232,6 +241,7 @@ func TestIsTransientGeminiError(t *testing.T) {
 		{"deadline exceeded", context.DeadlineExceeded, true},
 		{"wrapped deadline exceeded", fmt.Errorf("post failed: %w", context.DeadlineExceeded), true},
 		{"net timeout error", fakeTimeoutError{}, true},
+		{"net error without timeout (connection reset)", fakeConnResetError{}, true},
 		{"googleapi 429", &googleapi.Error{Code: 429}, true},
 		{"googleapi 500", &googleapi.Error{Code: 500}, true},
 		{"googleapi 503", &googleapi.Error{Code: 503}, true},
@@ -353,6 +363,20 @@ func TestGenerateContentWithRetry_AttemptContextBoundedByParent(t *testing.T) {
 	parentDeadline, _ := parentCtx.Deadline()
 	if gotDeadline.After(parentDeadline) {
 		t.Errorf("attempt deadline %v exceeds parent deadline %v", gotDeadline, parentDeadline)
+	}
+}
+
+func TestNewGeminiHTTPClient_BoundsHungConnections(t *testing.T) {
+	client := newGeminiHTTPClient()
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport = %T, want *http.Transport", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout <= 0 {
+		t.Error("ResponseHeaderTimeout must be set so a hung connection fails before the caller's context deadline")
+	}
+	if transport.IdleConnTimeout <= 0 {
+		t.Error("IdleConnTimeout must be set to avoid reusing stale idle connections")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Slack alerts (`ClipKit Contact`) showed 6+ `[VoiLog] Transcription failed (Gemini)` alerts over the past two days, mostly `context deadline exceeded`, some `read tcp` network errors.
- Cloud Run request logs for `/transcribe` show a stark bimodal pattern: successes finish in 10-17s, every failure lands at **exactly** ~481.5s — the 480s context budget added in #178, not genuinely slow processing. This is a hung connection that never returns.
- Root cause: `generateContentWithRetry`'s per-attempt timeout is derived from the same shared 480s parent context. By the time attempt 2 starts, that budget is nearly exhausted too, so the "retry" just hangs out the same clock on the same dead connection instead of getting a real second chance.
- Secondary bug: `isTransientGeminiError` only retried `net.Error` when `Timeout()==true`. A `read tcp: connection reset by peer` error (seen in the alerts) is a `net.Error` but not a timeout, so it silently skipped retry entirely.

## Fix
- Give the Gemini `genai.Client` a custom `http.Client` (`option.WithHTTPClient`) with `ResponseHeaderTimeout: 120s` and `IdleConnTimeout: 90s`, so a hung attempt fails fast (well above the observed 10-17s success time, well below the 480s hang) instead of consuming the whole shared budget — freeing room for `generateContentWithRetry` to actually retry over a fresh connection.
- Broaden `isTransientGeminiError` to treat any `net.Error` as transient regardless of `Timeout()`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all pass, including new `TestNewGeminiHTTPClient_BoundsHungConnections` and a `net.Error`-without-`Timeout()` case added to `TestIsTransientGeminiError`
- [x] Confirmed `golangci-lint` findings are pre-existing (identical before/after this diff), and not part of this repo's CI gate (`.github/workflows/backend-ci.yml` only runs build/vet/test for this server)
- [ ] Deploy to Cloud Run and monitor Slack alert volume over the next few days (deploy not included in this PR — flagging for whoever merges, per `gcloud run deploy --project voilog` in CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7yq2EzDfNoLWQgLhgTYWF