### PR TITLE
fix(ios): 文字起こしの広告視聴バイパスに無料回数の上限を追加

### DIFF
--- a/ios/VoiLog/Locate/Playback.xcstrings
+++ b/ios/VoiLog/Locate/Playback.xcstrings
@@ -5356,6 +5356,131 @@
         }
       }
     },
+    "無料でご利用いただける文字起こし（広告視聴で3回）を使い切りました。プレミアム会員に登録すると、引き続き無制限でご利用いただけます。7日間の無料トライアルもご利用いただけます。": {
+      "comment": "Premium prompt shown when the free (ad-based) transcription unlock limit has been reached",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie haben Ihre kostenlosen Transkriptionen (3, durch Ansehen von Anzeigen) aufgebraucht. Mit einem Premium-Abo erhalten Sie unbegrenzte Transkription – auch eine 7-tägige kostenlose Testversion ist verfügbar."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You've used up your free transcriptions (3, via watching ads). Subscribe to Premium for unlimited transcription — a 7-day free trial is available too."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Has agotado tus transcripciones gratuitas (3, viendo anuncios). Suscríbete a Premium para transcripción ilimitada; también hay una prueba gratuita de 7 días disponible."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous avez utilisé toutes vos transcriptions gratuites (3, en regardant des publicités). Abonnez-vous à Premium pour une transcription illimitée – un essai gratuit de 7 jours est aussi disponible."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hai esaurito le trascrizioni gratuite (3, guardando annunci). Abbonati a Premium per trascrizioni illimitate: è disponibile anche una prova gratuita di 7 giorni."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esgotou as suas transcrições gratuitas (3, ao assistir a anúncios). Subscreva o Premium para transcrição ilimitada — também está disponível um período experimental gratuito de 7 dias."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы использовали все бесплатные расшифровки (3, за просмотр рекламы). Оформите Premium-подписку для неограниченной расшифровки — также доступна бесплатная 7-дневная пробная версия."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ücretsiz transkripsiyon hakkınızı (reklam izleyerek kazanılan 3 hak) kullandınız. Sınırsız transkripsiyon için Premium'a abone olun — 7 günlük ücretsiz deneme de mevcuttur."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn đã dùng hết lượt phiên âm miễn phí (3 lượt, qua xem quảng cáo). Đăng ký Premium để phiên âm không giới hạn — cũng có bản dùng thử miễn phí 7 ngày."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您已用完免费文字转录次数（观看广告获得的3次）。订阅Premium即可无限次转录——还可享受7天免费试用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您已用完免費文字轉錄次數（觀看廣告獲得的3次）。訂閱Premium即可無限次轉錄——還可享受7天免費試用。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لقد استنفدت عمليات التفريغ الصوتي المجانية (3 عبر مشاهدة الإعلانات). اشترك في Premium للحصول على تفريغ صوتي غير محدود — تتوفر أيضًا نسخة تجريبية مجانية لمدة 7 أيام."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anda telah menghabiskan transkripsi gratis (3 kali, melalui menonton iklan). Berlangganan Premium untuk transkripsi tanpa batas — uji coba gratis 7 hari juga tersedia."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपने अपने मुफ़्त ट्रांसक्रिप्शन (विज्ञापन देखकर मिलने वाले 3) का उपयोग कर लिया है। असीमित ट्रांसक्रिप्शन के लिए Premium सब्सक्राइब करें — 7-दिन का मुफ़्त ट्रायल भी उपलब्ध है।"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Je hebt je gratis transcripties (3, via het bekijken van advertenties) verbruikt. Abonneer je op Premium voor onbeperkte transcriptie — er is ook een gratis proefperiode van 7 dagen beschikbaar."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wykorzystałeś już darmowe transkrypcje (3, za obejrzenie reklam). Subskrybuj Premium, aby uzyskać nieograniczoną transkrypcję — dostępny jest również 7-dniowy bezpłatny okres próbny."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du har använt dina gratis transkriberingar (3, genom att titta på annonser). Prenumerera på Premium för obegränsad transkribering – en 7-dagars gratis provperiod finns också."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คุณใช้สิทธิ์ถอดความฟรีครบแล้ว (3 ครั้งจากการดูโฆษณา) สมัคร Premium เพื่อถอดความได้ไม่จำกัด — พร้อมทดลองใช้ฟรี 7 วัน"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "무료로 이용할 수 있는 문자 변환(광고 시청으로 얻는 3회)을 모두 사용했습니다. 프리미엄을 구독하면 무제한으로 이용할 수 있으며, 7일 무료 체험도 가능합니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無料でご利用いただける文字起こし（広告視聴で3回）を使い切りました。プレミアム会員に登録すると、引き続き無制限でご利用いただけます。7日間の無料トライアルもご利用いただけます。"
+          }
+        }
+      }
+    },
     "文字起こしデータがありません": {
       "comment": "A message displayed when a voice memo does not have transcription data.",
       "isCommentAutoGenerated": true,

--- a/ios/VoiLog/Playback/PlaybackFeature.swift
+++ b/ios/VoiLog/Playback/PlaybackFeature.swift
@@ -5,6 +5,12 @@ import os.log
 
 @Reducer
 struct PlaybackFeature {
+  // 文字起こしプレミアムプロンプトを表示する理由（文言出し分け用）
+  enum TranscriptionPromptReason: Equatable {
+    case adSkipped
+    case freeLimitReached
+  }
+
   @ObservableState
   struct State: Equatable {
     var voiceMemos: [VoiceMemo] = []
@@ -34,6 +40,13 @@ struct PlaybackFeature {
     var selectedMemoForTranscription: VoiceMemo.ID?
     var showTranscriptionSheet = false
     var showTranscriptionPremiumPrompt = false
+    var transcriptionPromptReason: TranscriptionPromptReason = .adSkipped
+    // 広告視聴での無料アンロック回数（lifetime）。issue #207: 上限がなく無料で使い放題だった不具合の修正
+    var adBasedTranscriptionUnlockCount: Int = UserDefaultsManager.shared.adBasedTranscriptionUnlockCount
+
+    var hasFreeTranscriptionUnlockRemaining: Bool {
+      adBasedTranscriptionUnlockCount < UserDefaultsManager.freeAdBasedTranscriptionLimit
+    }
 
     // Apple transcription (timestampedText viewer)
     var selectedMemoForAppleTranscription: VoiceMemo.ID?
@@ -439,14 +452,7 @@ struct PlaybackFeature {
           state.showDetailSheet = false
           state.selectedMemoForDetails = nil
           state.selectedMemoForTranscription = memoID
-          guard state.hasPurchasedPremium else {
-            return .run { send in
-              await rewardedAdClient.show({ Task { @MainActor in send(.view(.rewardedAdCompleted)) } }, { Task { @MainActor in send(.view(.rewardedAdSkipped)) } }
-              )
-            }
-          }
-          state.showTranscriptionSheet = true
-          return .none
+          return startTranscriptionUnlockFlow(state: &state)
 
         case let .showCombinedTranscriptionFromDetail(memoID):
           state.showDetailSheet = false
@@ -496,21 +502,17 @@ struct PlaybackFeature {
 
         case let .showTranscription(memoID):
           state.selectedMemoForTranscription = memoID
-          guard state.hasPurchasedPremium else {
-            return .run { send in
-              await rewardedAdClient.show({ Task { @MainActor in send(.view(.rewardedAdCompleted)) } }, { Task { @MainActor in send(.view(.rewardedAdSkipped)) } }
-              )
-            }
-          }
-          state.showTranscriptionSheet = true
-          return .none
+          return startTranscriptionUnlockFlow(state: &state)
 
         case .rewardedAdCompleted:
+          state.adBasedTranscriptionUnlockCount += 1
+          UserDefaultsManager.shared.adBasedTranscriptionUnlockCount = state.adBasedTranscriptionUnlockCount
           state.showTranscriptionSheet = true
           return .none
 
         case .rewardedAdSkipped:
           state.selectedMemoForTranscription = nil
+          state.transcriptionPromptReason = .adSkipped
           state.showTranscriptionPremiumPrompt = true
           return .none
 
@@ -805,6 +807,25 @@ struct PlaybackFeature {
     )
   }
 
+  // 文字起こしの利用可否を判定する。プレミアム会員は即座に、無料会員は広告視聴での
+  // アンロック回数が上限（lifetime）に達していなければ広告フローへ、達していればアップグレード導線へ誘導する。
+  private func startTranscriptionUnlockFlow(state: inout State) -> Effect<Action> {
+    guard !state.hasPurchasedPremium else {
+      state.showTranscriptionSheet = true
+      return .none
+    }
+    guard state.hasFreeTranscriptionUnlockRemaining else {
+      state.selectedMemoForTranscription = nil
+      state.transcriptionPromptReason = .freeLimitReached
+      state.showTranscriptionPremiumPrompt = true
+      return .none
+    }
+    return .run { send in
+      await rewardedAdClient.show({ Task { @MainActor in send(.view(.rewardedAdCompleted)) } }, { Task { @MainActor in send(.view(.rewardedAdSkipped)) } }
+      )
+    }
+  }
+
   private func startPlayback(url: URL, startTime: TimeInterval = 0, playSpeed: AudioPlayerClient.PlaybackSpeed = .normal, volumeBoost: Float = 1.0) -> Effect<Action> {
     .run { send in
       // 音声再生開始
@@ -892,7 +913,12 @@ struct PlaybackView: View {
           send(.dismissTranscriptionPremiumPrompt)
         }
       } message: {
-        Text(String(localized: "文字起こしはプレミアム会員なら無制限で利用できます。広告を視聴すると1回ご利用いただけます。", table: "Playback"))
+        switch store.transcriptionPromptReason {
+        case .adSkipped:
+          Text(String(localized: "文字起こしはプレミアム会員なら無制限で利用できます。広告を視聴すると1回ご利用いただけます。", table: "Playback"))
+        case .freeLimitReached:
+          Text(String(localized: "無料でご利用いただける文字起こし（広告視聴で3回）を使い切りました。プレミアム会員に登録すると、引き続き無制限でご利用いただけます。7日間の無料トライアルもご利用いただけます。", table: "Playback"))
+        }
       }
       .fullScreenCover(isPresented: $store.showDetailSheet) {
         if let selectedId = store.selectedMemoForDetails,

--- a/ios/VoiLog/data/UserDefaultsManager.swift
+++ b/ios/VoiLog/data/UserDefaultsManager.swift
@@ -167,4 +167,18 @@ class UserDefaultsManager {
             defaults.set(newValue, forKey: "PlaybackVolumeBoost")
         }
     }
+
+    // 広告視聴による文字起こし無料アンロック回数の上限（lifetime）
+    // 参考: issue #207 (無料枠が無制限になっていた不具合の修正)
+    static let freeAdBasedTranscriptionLimit = 3
+
+    // 広告視聴で文字起こしをアンロックした回数（lifetime、購入前提の回数のみカウント）
+    var adBasedTranscriptionUnlockCount: Int {
+        get {
+            defaults.integer(forKey: "AdBasedTranscriptionUnlockCount")
+        }
+        set {
+            defaults.set(newValue, forKey: "AdBasedTranscriptionUnlockCount")
+        }
+    }
 }

--- a/ios/VoiLogTests/PlaybackFeatureTests.swift
+++ b/ios/VoiLogTests/PlaybackFeatureTests.swift
@@ -441,6 +441,116 @@ final class PlaybackFeatureTests: XCTestCase {
             await store.send(.view(.showTranscription(memoID)))
             await store.receive(\.view.rewardedAdSkipped) {
                 $0.selectedMemoForTranscription = nil
+                $0.transcriptionPromptReason = .adSkipped
+                $0.showTranscriptionPremiumPrompt = true
+            }
+        }
+    }
+
+    // MARK: - 無料アンロック上限（issue #207: 広告視聴バイパスに上限がなく無料で使い放題だった不具合の修正）
+
+    func testShowTranscription_freeUser_belowLimit_watchesAdAndIncrementsUnlockCount() async {
+        await withMainSerialExecutor {
+            UserDefaultsManager.shared.adBasedTranscriptionUnlockCount = 1
+
+            let memoID = UUID()
+            var initialState = PlaybackFeature.State()
+            initialState.hasPurchasedPremium = false
+            var rewardedCalled = false
+
+            let store = TestStore(initialState: initialState) {
+                PlaybackFeature()
+            } withDependencies: {
+                $0.voiceMemoRepository = mockRepository()
+                $0.audioPlayer = AudioPlayerClient(
+                    play: { _, _, _, _, _ in true }, stop: { true }, getCurrentTime: { 0 }
+                )
+                $0.rewardedAdClient = RewardedAdClient(
+                    preload: { },
+                    show: { onRewarded, _ in
+                        rewardedCalled = true
+                        onRewarded()
+                    }
+                )
+            }
+            store.exhaustivity = .off
+
+            XCTAssertEqual(store.state.adBasedTranscriptionUnlockCount, 1)
+            XCTAssertTrue(store.state.hasFreeTranscriptionUnlockRemaining)
+
+            await store.send(.view(.showTranscription(memoID)))
+            await store.receive(\.view.rewardedAdCompleted) {
+                $0.adBasedTranscriptionUnlockCount = 2
+                $0.showTranscriptionSheet = true
+            }
+            XCTAssertTrue(rewardedCalled)
+            XCTAssertEqual(UserDefaultsManager.shared.adBasedTranscriptionUnlockCount, 2)
+
+            // cleanup
+            UserDefaultsManager.shared.adBasedTranscriptionUnlockCount = 0
+        }
+    }
+
+    func testShowTranscription_freeUser_atLimit_skipsAdAndShowsFreeLimitReachedPrompt() async {
+        await withMainSerialExecutor {
+            UserDefaultsManager.shared.adBasedTranscriptionUnlockCount = 0
+
+            let memoID = UUID()
+            var initialState = PlaybackFeature.State()
+            initialState.hasPurchasedPremium = false
+            initialState.adBasedTranscriptionUnlockCount = UserDefaultsManager.freeAdBasedTranscriptionLimit
+
+            let store = TestStore(initialState: initialState) {
+                PlaybackFeature()
+            } withDependencies: {
+                $0.voiceMemoRepository = mockRepository()
+                $0.audioPlayer = AudioPlayerClient(
+                    play: { _, _, _, _, _ in true }, stop: { true }, getCurrentTime: { 0 }
+                )
+                $0.rewardedAdClient = RewardedAdClient(
+                    preload: { },
+                    show: { _, _ in XCTFail("free-limit到達後は広告を出さずpremium promptへ直行するべき") }
+                )
+            }
+            store.exhaustivity = .off
+
+            XCTAssertFalse(store.state.hasFreeTranscriptionUnlockRemaining)
+
+            await store.send(.view(.showTranscription(memoID))) {
+                $0.selectedMemoForTranscription = nil
+                $0.transcriptionPromptReason = .freeLimitReached
+                $0.showTranscriptionPremiumPrompt = true
+            }
+        }
+    }
+
+    func testShowGeminiTranscriptionFromDetail_freeUser_atLimit_skipsAdAndShowsFreeLimitReachedPrompt() async {
+        await withMainSerialExecutor {
+            let memoID = UUID()
+            var initialState = PlaybackFeature.State()
+            initialState.hasPurchasedPremium = false
+            initialState.adBasedTranscriptionUnlockCount = UserDefaultsManager.freeAdBasedTranscriptionLimit
+            initialState.selectedMemoForDetails = memoID
+            initialState.showDetailSheet = true
+
+            let store = TestStore(initialState: initialState) {
+                PlaybackFeature()
+            } withDependencies: {
+                $0.voiceMemoRepository = mockRepository()
+                $0.audioPlayer = AudioPlayerClient(
+                    play: { _, _, _, _, _ in true }, stop: { true }, getCurrentTime: { 0 }
+                )
+                $0.rewardedAdClient = RewardedAdClient(
+                    preload: { },
+                    show: { _, _ in XCTFail("free-limit到達後は広告を出さずpremium promptへ直行するべき") }
+                )
+            }
+            store.exhaustivity = .off
+
+            await store.send(.view(.showGeminiTranscriptionFromDetail(memoID))) {
+                $0.showDetailSheet = false
+                $0.selectedMemoForDetails = nil
+                $0.transcriptionPromptReason = .freeLimitReached
                 $0.showTranscriptionPremiumPrompt = true
             }
         }


### PR DESCRIPTION
## 背景

closes #207

MRR横ばい調査(2026-07-26)で判明した問題の修正。iOS版の文字起こし機能は `hasPurchasedPremium == false` の場合、リワード広告を1本視聴するだけで1回分アンロックされる実装だったが、この**アンロックに回数上限が一切なく**、無料ユーザーが「広告を見る→使う」を無限に繰り返すことでプレミアムの目玉機能「AI文字起こし無制限」を実質無料で使い続けられていた。Android版(`MeetingMinutesScreen.kt`)は`isPremium`でハードゲートされておりこの抜け穴は存在せず、iOS/Android間で導線が非対称だった。

## 変更内容

- `UserDefaultsManager`に広告視聴アンロック回数を永続化するカウンタ(`adBasedTranscriptionUnlockCount`)と上限定数(`freeAdBasedTranscriptionLimit = 3`)を追加
- `PlaybackFeature`の`showTranscription`/`showGeminiTranscriptionFromDetail`を、共通の`startTranscriptionUnlockFlow`経由に統一
  - プレミアム会員: 従来通り即座にシートを開く
  - 無料会員・上限未到達: 従来通り広告視聴フロー
  - 無料会員・上限到達: **広告を出さず**、直接プレミアムアップグレードのプロンプトへ誘導
- プレミアムプロンプトのアラート文言を、理由(`.adSkipped` / `.freeLimitReached`)で出し分け。上限到達時は「無料でご利用いただける文字起こし(広告視聴で3回)を使い切りました。プレミアム会員に登録すると、引き続き無制限でご利用いただけます。7日間の無料トライアルもご利用いただけます。」と明示し、なぜブロックされたか・どうすれば良いかを案内(Playback.xcstringsに20言語分追加)
- 既存ユーザーへの配慮(急な締め出しを避ける設計):
  - カウンタは今回のリリース以降の利用のみを数える(過去の利用回数を遡及して数えない= 実質的な移行期間として、既存ユーザーも更新後に3回分の無料お試しが残る)
  - 上限到達時は無言でブロックするのではなく、理由と次のアクション(プレミアム登録・7日間トライアル)を明示するアラートを表示

## スコープ外

サーバー側(`server/transcription/main.go`)でのプレミアム会員判定の実装は別issue(#208)として起票済み。本PRはクライアント側の穴の是正のみ。

## テスト

- 新規: 上限未到達時は従来通り広告フローが動くこと / 上限到達時は広告を出さずpremium promptへ直行すること(`showTranscription`・`showGeminiTranscriptionFromDetail`両方)をTestStoreで検証
- 既存の`rewardedAdSkipped`テストに`transcriptionPromptReason`のアサーションを追加

```
xcodebuild test -project ios/VoiLog.xcodeproj -scheme VoiLogTests -destination 'id=B4D6D6E0-E997-4F0F-9272-E606FD3D17EC'
→ ** TEST SUCCEEDED ** (147 tests passed, 0 failures)

cd ios && swiftlint --fix && swiftlint
→ 変更ファイル(PlaybackFeature.swift, UserDefaultsManager.swift)は0 violations
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)